### PR TITLE
docs: Rewrite agent governance — GitHub Issues = source of truth

### DIFF
--- a/.ralph/AGENTS.md
+++ b/.ralph/AGENTS.md
@@ -1,99 +1,83 @@
-# AGENTS.md — Agent Development Rules
+# AGENTS.md — Agent Work Rules (GitHub Issues = Source of Truth)
 
-## Parallel Documentation Rule
+## Core Principle
 
-**ALL agents MUST document website changes in parallel with code changes.**
+> Agents do NOT work without a GitHub Issue.
+> No issue = no task = no code = no PR.
 
-### The Golden Rule
+## Agent Lifecycle
 
-> "Code without website documentation is HALF-DONE."
+1. **IDLE** — Poll `gh issue list --label assign:ralph --label status:pending`
+2. **CLAIM** — Add `status:in-progress` label, assign self
+3. **BRANCH** — `git worktree add ../trinity-w{N} -b ralph/w{N}/{issue-slug} origin/main`
+4. **WORK** — VIBEE-first: spec → gen → test → bench → assess
+5. **PR** — `gh pr create --base main --body "Closes #N"` with ALL metadata (RULE #20)
+6. **REPORT** — Comment on issue with results, metrics, assessment
+7. **DONE** — General merges PR → issue auto-closes → board updates
 
-### Every Agent Action Requires
+## Issue as Workspace
 
-1. Code Change → Update `website/src/services/chatApi.ts`
-2. New Widget → Add to `website/src/components/sections/`
-3. New Feature → Create `docs/docs/features/<feature>.md`
-4. API Change → Update `docs/docs/api/`
+All communication happens ON THE ISSUE:
+- Progress updates → issue comments
+- Blockers → issue comment with warning
+- Benchmarks → issue comment with table
+- Questions → issue comment mentioning @gHashTag
+- Final report → issue comment with summary
 
-### Checklist Before Commit
+## Rules
 
-```bash
-cd website && npm run build
-cd ../docs && npm run build
-git add website/ docs/
-git commit "feat: <feature> + website docs"
+### RULE #19: Issue Metadata
+Every issue MUST have: assignee, labels (`assign:ralph` + `priority:P0-P3` + `status:*`), milestone, project (VIBECODER #6), relationship (linked to parent epic).
+
+### RULE #20: PR Metadata
+Every PR MUST have: assignee, labels (same as linked issue + `status:in-progress`), milestone, reviewer (gHashTag), linked issues (`Closes #N` in body), project (VIBECODER #6).
+
+### RULE #21: No Work Without Issue
+Agent MUST NOT:
+- Write code without an assigned issue
+- Push commits without PR linked to issue
+- Create branches without issue number in name
+- Close issues manually (only via PR merge)
+
+### RULE #22: GitHub Issues = Source of Truth
+- All tasks come from `gh issue list --label assign:ralph`
+- `fix_plan.md` is DEPRECATED as task source
+- If no pending issues exist, agent is IDLE
+- New work = new GitHub Issue first, then branch + code
+
+## Sub-agents
+
+Parent agent creates sub-issues for sub-agents:
+```
+Parent Issue #38 (epic, label: swarm:parent)
+  |- Sub-issue #39 -> Agent-W1
+  |- Sub-issue #40 -> Agent-W2
+  +- Sub-issue #41 -> Agent-W3
 ```
 
-### Exit Criteria
+Sub-agent follows same lifecycle: claim → branch → work → PR → done.
+Parent issue progress bar updates automatically via sub-issues.
 
-A task is COMPLETE only when:
+## Forbidden
 
-- [ ] Code works (tests pass)
-- [ ] `website/` updated (API functions, components)
-- [ ] `docs/docs/` updated (documentation pages)
-- [ ] Both sites build successfully
-- [ ] Changes committed together
+- Working on main branch
+- Working without issue
+- Creating PR without "Closes #N"
+- Empty issue metadata (no labels, no milestone)
+- Manual issue close (only via PR merge)
+- Editing generated files (`trinity/output/`, `generated/`)
+- Pushing to main directly
+- Reporting "done" without confirmed push
 
-### Parallel Development Mapping
+## Monitoring
 
-| Development Phase | Website Action |
-|-------------------|----------------|
-| **Spec** | Create draft doc in `docs/docs/` |
-| **Generate** | Add API to `chatApi.ts` |
-| **Implement** | Create/update feature component |
-| **Test** | Update benchmarks page |
-| **Document** | Update docs + sidebars |
-| **Commit** | Include both code and website |
-
-### Mandatory File Updates
-
-For ANY feature addition:
-
-```
-website/src/services/chatApi.ts        # API functions
-website/src/components/sections/       # Feature widgets
-docs/docs/                          # Technical docs
-docs/sidebars.ts                    # Navigation
-```
-
-### Deployment Rule
-
-**ALWAYS deploy website and docs TOGETHER with code.**
-
-See `CLAUDE.md` → "Deployment (GitHub Pages)" for full procedure.
-
----
-
-## Quick Reference
-
-### Add API Function
-
-```typescript
-// website/src/services/chatApi.ts
-export async function myFeature(input: string): Promise<Result> {
-  return fetchWithError('/api/my-feature', { input });
-}
-```
-
-### Add Widget
-
-```tsx
-// website/src/components/sections/MyFeatureWidget.tsx
-export function MyFeatureWidget() {
-  // Use glassStyle() + column colors
-}
-```
-
-### Add Documentation
-
-```markdown
-# docs/docs/features/my-feature.md
----
-title: My Feature
-sidebar_position: 10
----
-```
+Oracle Watchdog monitors all agents 24/7:
+- Telegram alerts on commit, stop, circuit breaker
+- GitHub Projects board (VIBECODER #6) shows real-time status
+- `/god-mode` skill shows full dashboard
+- GitHub Actions auto-update board on PR merge / issue close
 
 ---
 
 *This file is part of the Ralph Autonomous Development System.*
+*GitHub Issues = single source of truth. No exceptions.*

--- a/.ralph/RULES.md
+++ b/.ralph/RULES.md
@@ -1,4 +1,4 @@
-# Ralph Development Rules (16 Sections)
+# Ralph Development Rules (22 Sections)
 
 ## 1. Source of Truth
 - `specs/tri/*.vibee` governs ALL application code
@@ -124,3 +124,22 @@ Every PR created by agent MUST have:
 6. Project — same board as linked issue
 
 PR without metadata = invisible work = violation.
+
+## 21. No Work Without Issue (MANDATORY)
+Agent MUST NOT:
+1. Write code without an assigned GitHub Issue
+2. Push commits without a PR linked to an issue
+3. Create branches without issue number in name (`ralph/w{N}/{slug}`)
+4. Close issues manually — only via PR merge with `Closes #N`
+5. Report "done" without confirmed `git push` + GitHub API verification
+
+No issue = no task = no code = no PR. Period.
+
+## 22. GitHub Issues = Source of Truth (MANDATORY)
+- ALL tasks come from `gh issue list --label assign:ralph`
+- `fix_plan.md` is DEPRECATED as primary task source
+- If no pending issues exist → agent is IDLE (do not invent work)
+- New work requires: create GitHub Issue first → then branch → then code
+- GitHub Projects board (VIBECODER #6) is the canonical view of all work
+- GitHub Actions auto-add issues to project and auto-update status on merge
+- Oracle Watchdog monitors GitHub API and reports to Telegram 24/7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,17 +471,64 @@ git push origin gh-pages --force
 
 ## Ralph Autonomous Development (MANDATORY)
 
-**ALL development MUST go through Ralph.** This saves time by enforcing quality gates, tech tree navigation, memory consultation, and structured workflows automatically.
+### Single Source of Truth: GitHub Issues
 
-### Why Ralph-Only
+ALL work flows through GitHub Issues. No internal task queues, no `fix_plan.md` as primary source.
 
-| Without Ralph | With Ralph |
-|--------------|-----------|
-| Manual quality checks | Automated gates (build + test + format) |
-| Forget to update tech tree | Tree updated every cycle |
-| Repeat past mistakes | REGRESSION_PATTERNS.md consulted |
-| No structured progress | fix_plan.md + TECH_TREE.md tracking |
-| Commits to main | Feature branches enforced |
+| Component | Role |
+|-----------|------|
+| **GitHub Issues** | Task queue, status tracking, progress |
+| **GitHub Projects** | Board view (VIBECODER #6) |
+| **GitHub PRs** | Code delivery, auto-closes issues on merge |
+| **MCP Swarm** | Execution engine (Zig, 11+ tools) |
+| **Oracle Watchdog** | 24/7 monitoring → Telegram @vibee_dev_bot |
+
+### How Work Happens
+
+1. **Issue created** with `assign:ralph` label → appears on VIBECODER board
+2. **Agent picks issue** → `gh issue edit N --add-label status:in-progress`
+3. **Agent creates branch** → `ralph/w{N}/{slug}`
+4. **Agent works** → VIBEE-first: spec → gen → test → assess
+5. **Agent creates PR** → `Closes #N` in body, all metadata filled (RULE #20)
+6. **General reviews** → merge → issue auto-closes → board updates
+7. **Oracle reports** → Telegram notification of progress
+
+### Issue Requirements (RULE #19)
+
+Every issue MUST have:
+1. Assignee
+2. Labels: `assign:ralph` + `priority:P0-P3` + `status:pending`
+3. Milestone: current active milestone
+4. Project: VIBECODER (#6)
+5. Relationship: linked to parent epic
+
+### PR Requirements (RULE #20)
+
+Every PR MUST have:
+1. Assignee
+2. Labels (same as linked issue + `status:in-progress`)
+3. Milestone
+4. Reviewer: gHashTag
+5. Body: `Closes #N` for linked issues
+6. Project: VIBECODER (#6)
+
+### Branch Strategy
+
+- `main` — protected, merge only via PR
+- `ralph/w{N}/{issue-slug}` — agent worktree branches
+- Never push to main directly
+
+### MCP Swarm Tools
+
+| Tool | Purpose |
+|------|---------|
+| `swarm_task_add` | Creates GitHub Issue + links to parent |
+| `swarm_task_get` | Gets next pending issue |
+| `swarm_status` | Reads GitHub API, returns board state |
+| `swarm_heartbeat` | Comments progress on issue |
+| `swarm_register` | Register agent in swarm |
+| `swarm_agents` | List active agents |
+| `oracle_start/stop/status` | Control Telegram watchdog |
 
 ### Configuration
 
@@ -489,57 +536,32 @@ git push origin gh-pages --force
 .ralph/
 ├── PROMPT.md              # Autonomous work instructions
 ├── AGENT.md               # Build/test/run commands
-├── RULES.md               # Universal development guardrails (16 sections)
-├── TECH_TREE.md            # Tech tree navigation (35 nodes, 6 branches)
-├── fix_plan.md             # Current sprint tasks with acceptance criteria
-├── SUCCESS_HISTORY.md      # Working patterns + commit hashes
-├── REGRESSION_PATTERNS.md  # Anti-patterns + root causes
+├── AGENTS.md              # Agent work rules (GitHub Issues lifecycle)
+├── RULES.md               # Universal development guardrails (22 rules)
+├── TECH_TREE.md            # Tech tree navigation
+├── memory/
+│   ├── SUCCESS_HISTORY.md  # Working patterns + commit hashes
+│   └── REGRESSION_PATTERNS.md  # Anti-patterns + root causes
 ├── specs/                  # Ralph-specific specs
-├── examples/               # Workflow examples
-├── logs/                   # Execution logs
-└── docs/generated/         # Auto-generated docs
+└── logs/                   # Execution logs
 .ralphrc                    # Runtime settings (tools, timeouts, gates)
-```
-
-### How to Use
-
-```bash
-# 1. Add task to .ralph/fix_plan.md (with acceptance criteria)
-# 2. Start Ralph
-ralph --monitor
-
-# Ralph will:
-#   - Read TECH_TREE.md, fix_plan.md, SUCCESS_HISTORY.md, REGRESSION_PATTERNS.md
-#   - Pick highest-priority task
-#   - Create ralph/<task-slug> branch
-#   - Implement via Golden Chain cycle (spec → gen → test → assess → tree → commit)
-#   - Run quality gates (build + test + format)
-#   - Update tech tree and memory files
-#   - Loop until EXIT_SIGNAL = true
-```
-
-### Commands
-
-```bash
-ralph --monitor          # Start with live monitoring dashboard
-ralph --help             # Show options
-ralph-enable             # Enable Ralph in project
-ralph-import prd.md      # Convert PRD to Ralph tasks
 ```
 
 ### Safeguards
 
-- Rate limiting: 100 calls/hour (configurable)
-- Circuit breaker: 3 no-progress loops → cooldown
-- Branch safety: never commits to main
-- Quality gates: build + test + format before every commit
+- Circuit breaker: 5 no-progress loops → OPEN
+- Branch safety: hooks warn on main branch
+- Quality gates: build + test + format before commit
 - Memory: consults SUCCESS_HISTORY and REGRESSION_PATTERNS every loop
-- Dual-condition exit: heuristic indicators + explicit EXIT_SIGNAL
+- GOD MODE: `/god-mode` skill for full dashboard
+- Oracle: 24/7 Telegram monitoring
 
-### Current Task (via Ralph)
+### Automation (GitHub Actions)
 
-**VSA Mathematical Framework** — proofs + optimizations for bind/unbind/bundle, multilingual code gen.
-See `.ralph/fix_plan.md` and `.ralph/TECH_TREE.md` for details.
+| Workflow | Trigger | Action |
+|----------|---------|--------|
+| `project-auto-add.yml` | Issue/PR labeled | Auto-add to VIBECODER board |
+| `project-auto-status.yml` | PR merged / Issue closed | Auto-move to Done |
 
 Repository: https://github.com/frankbria/ralph-claude-code
 
@@ -599,6 +621,7 @@ Full Claude Code modernization: MCP servers, custom skills, automation hooks, pa
 | **trinity** | `zig-out/bin/trinity-mcp` | 35+ (codegen, math, git, sacred, omega) | `.mcp.json` |
 | **needle** | `zig-out/bin/needle-mcp` | 6 (structural_replace, search, quality_gates, preview, batch_edit, autonomous_refactor) | `.mcp.json` |
 | **zig-docs** | `npx @nichochar/zig-mcp` | 4 (list/get builtins, search/get std lib) | `.mcp.json` |
+| **railway** | `npx @railway/mcp-server` | deploy, logs, env vars, domains, services | `.mcp.json` |
 | **vibee** | `vibee/gleam/run_mcp.sh` | VIBEE compiler tools | `~/.claude/settings.json` |
 | **neon** | `npx @neondatabase/mcp-server-neon` | Database management | `~/.claude/settings.json` |
 
@@ -610,6 +633,8 @@ Full Claude Code modernization: MCP servers, custom skills, automation hooks, pa
 | `/vsa-verify` | VSA mathematical proof verification | `.claude/skills/vsa-verify/SKILL.md` |
 | `/vibee-gen` | Generate Zig/Verilog from .vibee specs | `.claude/skills/vibee-gen/SKILL.md` |
 | `/trinity-test` | Run test suites with analysis | `.claude/skills/trinity-test/SKILL.md` |
+| `/god-mode` | Agent monitoring dashboard (GOD MODE) | `.claude/skills/god-mode/SKILL.md` |
+| `/railway-ssh` | Railway cloud server management | `.claude/skills/railway-ssh/SKILL.md` |
 
 ### Automation Hooks (6 events)
 
@@ -641,7 +666,12 @@ Full Claude Code modernization: MCP servers, custom skills, automation hooks, pa
 
 | Variable | Value | Purpose |
 |----------|-------|---------|
-| `TRINITY_PROJECT_ROOT` | `/Users/playra/trinity-w1` | Project root for hooks/scripts |
+| `GH_TOKEN` | (secret) | GitHub API for swarm tools |
+| `TELEGRAM_BOT_TOKEN` | (secret) | Oracle → Telegram |
+| `TELEGRAM_CHAT_ID` | `144022504` | Oracle chat target |
+| `ORACLE_ENABLED` | `true` | Auto-start Oracle on MCP init |
+| `GITHUB_OWNER` | `gHashTag` | Repo owner for swarm |
+| `GITHUB_REPO` | `trinity` | Repo name for swarm |
 | `ZIG_VERSION` | `0.15` | Zig version constraint |
 | `TRINITY_MCP_PORT` | `8899` | MCP server port |
 
@@ -652,7 +682,7 @@ Trinity packaged as Claude Code plugin in `.claude-plugin/`:
 ```
 .claude-plugin/
   plugin.json              # trinity-vsa-framework v1.0.0
-  skills/                  # 4 custom skills
+  skills/                  # 6 custom skills
   hooks/hooks.json         # 6 hook events (all synced with global)
   .mcp.json                # trinity + needle + zig-docs servers
 ```


### PR DESCRIPTION
## Summary

- **CLAUDE.md**: Replace fix_plan.md-based Ralph workflow with GitHub Issues lifecycle. Add MCP Swarm tools, issue/PR requirements (RULE #19/#20), branch strategy. Add `/god-mode` and `/railway-ssh` skills, `railway` MCP server, swarm env vars.
- **.ralph/AGENTS.md**: Full rewrite — agent lifecycle (IDLE→CLAIM→BRANCH→WORK→PR→REPORT→DONE), sub-agent architecture, forbidden actions, Oracle monitoring.
- **.ralph/RULES.md**: Add RULE #21 (No Work Without Issue), RULE #22 (GitHub Issues = Source of Truth). Update header 16→22 sections.

Closes #42

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify AGENTS.md agent lifecycle matches actual swarm behavior
- [ ] Verify RULES.md numbering is sequential (no gaps)
- [ ] Confirm no references to fix_plan.md as primary task source remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)