### PR TITLE
fix(agent): Add emojis to Telegram messages

### DIFF
--- a/tools/mcp/trinity_mcp/agent/agent_loop.zig
+++ b/tools/mcp/trinity_mcp/agent/agent_loop.zig
@@ -45,11 +45,11 @@ pub fn run(allocator: std.mem.Allocator, config: Config) !void {
 
         // Telegram: announce wake
         var tg_buf: [512]u8 = undefined;
-        telegram.sendFmt(config.tg_config, &tg_buf, "<b>ralph</b> | WAKE #{d}", .{wake_count});
+        telegram.sendFmt(config.tg_config, &tg_buf, "\xf0\x9f\xa4\x96 <b>ralph</b> WAKE #{d}", .{wake_count});
 
         if (config.max_wakes > 0 and wake_count > config.max_wakes) {
             log("Max wakes ({d}) reached. Exiting.", .{config.max_wakes});
-            telegram.send(config.tg_config, "<b>ralph</b> | Max wakes reached. Stopping.");
+            telegram.send(config.tg_config, "\xf0\x9f\x9b\x91 <b>ralph</b> Max wakes reached.");
             break;
         }
 
@@ -73,14 +73,14 @@ pub fn run(allocator: std.mem.Allocator, config: Config) !void {
 
         if (issues_json == null) {
             log("No pending issues or GitHub API unavailable. Sleeping.", .{});
-            telegram.send(config.tg_config, "<b>ralph</b> | No issues found. Sleeping.");
+            telegram.send(config.tg_config, "\xf0\x9f\x98\xb4 <b>ralph</b> No issues. Sleeping.");
             if (config.single_shot) break;
             std.Thread.sleep(config.sleep_interval_s * std.time.ns_per_s);
             continue;
         }
 
         // Telegram: issues found
-        telegram.sendFmt(config.tg_config, &tg_buf, "<b>ralph</b> | Issues found, building context...", .{});
+        telegram.sendFmt(config.tg_config, &tg_buf, "\xf0\x9f\x93\x8b <b>ralph</b> Issues found, building context...", .{});
 
         // Read current state
         const current_issue = state.read("current_issue");
@@ -105,7 +105,7 @@ pub fn run(allocator: std.mem.Allocator, config: Config) !void {
         const use_continue = wake_count > 1;
 
         // Telegram: spawning Claude
-        telegram.sendFmt(config.tg_config, &tg_buf, "<b>ralph</b> | Spawning Claude ({d}b context, {s})...", .{
+        telegram.sendFmt(config.tg_config, &tg_buf, "\xf0\x9f\xa7\xa0 <b>ralph</b> Spawning Claude ({d}b, {s})...", .{
             prompt.len,
             if (use_continue) "--continue" else "new session",
         });
@@ -119,7 +119,7 @@ pub fn run(allocator: std.mem.Allocator, config: Config) !void {
             use_continue,
         ) catch |err| {
             log("Claude spawn error: {s}", .{@errorName(err)});
-            telegram.sendFmt(config.tg_config, &tg_buf, "<b>ralph</b> | Claude spawn FAILED: {s}", .{@errorName(err)});
+            telegram.sendFmt(config.tg_config, &tg_buf, "\xe2\x9d\x8c <b>ralph</b> Claude spawn FAILED: {s}", .{@errorName(err)});
             if (config.single_shot) break;
             std.Thread.sleep(config.sleep_interval_s * std.time.ns_per_s);
             continue;
@@ -130,9 +130,9 @@ pub fn run(allocator: std.mem.Allocator, config: Config) !void {
 
         // Telegram: Claude finished
         if (result.exit_code == 0) {
-            telegram.sendFmt(config.tg_config, &tg_buf, "<b>ralph</b> | Claude done ({d}b output)", .{result.stdout.len});
+            telegram.sendFmt(config.tg_config, &tg_buf, "\xe2\x9c\x85 <b>ralph</b> Claude done ({d}b)", .{result.stdout.len});
         } else {
-            telegram.sendFmt(config.tg_config, &tg_buf, "<b>ralph</b> | Claude exit={d} ({d}b output)", .{ result.exit_code, result.stdout.len });
+            telegram.sendFmt(config.tg_config, &tg_buf, "\xe2\x9a\xa0\xef\xb8\x8f <b>ralph</b> exit={d} ({d}b)", .{ result.exit_code, result.stdout.len });
         }
 
         // Save session log
@@ -146,12 +146,12 @@ pub fn run(allocator: std.mem.Allocator, config: Config) !void {
 
         if (config.single_shot) {
             log("Single-shot mode. Exiting.", .{});
-            telegram.send(config.tg_config, "<b>ralph</b> | Single-shot done. Exiting.");
+            telegram.send(config.tg_config, "\xf0\x9f\x8f\x81 <b>ralph</b> Done.");
             break;
         }
 
         log("Sleeping for {d}s...", .{config.sleep_interval_s});
-        telegram.sendFmt(config.tg_config, &tg_buf, "<b>ralph</b> | Sleeping {d}s...", .{config.sleep_interval_s});
+        telegram.sendFmt(config.tg_config, &tg_buf, "\xf0\x9f\x98\xb4 <b>ralph</b> Sleeping {d}s...", .{config.sleep_interval_s});
         std.Thread.sleep(config.sleep_interval_s * std.time.ns_per_s);
     }
 

--- a/tools/mcp/trinity_mcp/agent/main.zig
+++ b/tools/mcp/trinity_mcp/agent/main.zig
@@ -58,6 +58,9 @@ pub fn main() !void {
             std.process.exit(1);
         };
         defer allocator.free(result.stderr);
+        // Note: result.stdout is intentionally NOT freed here — it's used as project_root
+        // for the lifetime of the program. The GPA will report it as "leaked" but it's
+        // needed until process exit.
         if (result.stdout.len == 0) {
             std.debug.print("[ralph-agent] ERROR: Not in a git repository.\n", .{});
             std.process.exit(1);

--- a/tools/mcp/trinity_mcp/agent/ralph_hook.zig
+++ b/tools/mcp/trinity_mcp/agent/ralph_hook.zig
@@ -39,15 +39,15 @@ pub fn main() !void {
     // Format message based on event type
     var buf: [512]u8 = undefined;
     const msg = if (std.mem.eql(u8, event, "PostToolUse"))
-        std.fmt.bufPrint(&buf, "<b>ralph</b> | {s} done", .{truncate(tool, 40)}) catch return
+        std.fmt.bufPrint(&buf, "\xe2\x9c\x85 <b>{s}</b> done", .{truncate(tool, 40)}) catch return
     else if (std.mem.eql(u8, event, "PostToolUseFailure"))
-        std.fmt.bufPrint(&buf, "<b>ralph</b> | {s} FAILED", .{truncate(tool, 40)}) catch return
+        std.fmt.bufPrint(&buf, "\xe2\x9d\x8c <b>{s}</b> FAILED", .{truncate(tool, 40)}) catch return
     else if (std.mem.eql(u8, event, "PreToolUse"))
-        std.fmt.bufPrint(&buf, "<b>ralph</b> | {s}...", .{truncate(tool, 40)}) catch return
+        std.fmt.bufPrint(&buf, "\xf0\x9f\x94\xa7 <b>{s}</b>...", .{truncate(tool, 40)}) catch return
     else if (std.mem.eql(u8, event, "Stop"))
-        std.fmt.bufPrint(&buf, "<b>ralph</b> | Session finished", .{}) catch return
+        std.fmt.bufPrint(&buf, "\xf0\x9f\x98\xb4 Session finished", .{}) catch return
     else if (std.mem.eql(u8, event, "SessionStart"))
-        std.fmt.bufPrint(&buf, "<b>ralph</b> | Session started", .{}) catch return
+        std.fmt.bufPrint(&buf, "\xf0\x9f\xa4\x96 Session started", .{}) catch return
     else
         return; // Unknown event, skip
 


### PR DESCRIPTION
## Summary

- Add emoji prefixes to all Telegram messages from ralph-agent and ralph-hook
- `🤖 ralph WAKE #N`, `😴 Sleeping`, `✅ Bash done`, `❌ FAILED`, etc.
- Document intentional stdout lifetime in main.zig (GPA reports as leak but it's used until exit)

**3 files changed, 18 insertions, 15 deletions.**

Closes #47

## Test plan

- [x] `zig build` compiles successfully
- [x] ralph-hook sends emoji messages to Telegram
- [x] ralph-agent v2.0.0 runs with Telegram enabled, Wake #5 and #6 completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)