### PR TITLE
feat(bot): /model, /resume, /sessions commands (Issue #56)

### DIFF
--- a/tools/mcp/trinity_mcp/bot/bot_loop.zig
+++ b/tools/mcp/trinity_mcp/bot/bot_loop.zig
@@ -1,5 +1,5 @@
 // bot_loop.zig — Main poll → parse → dispatch → repeat loop
-// Phase 2: Two-thread arch — main thread polls, worker thread streams Claude output
+// Phase 2.5: Two-thread arch + session management (/model, /resume, /sessions)
 const std = @import("std");
 const telegram_api = @import("telegram_api.zig");
 const json_utils = @import("json_utils.zig");
@@ -12,6 +12,9 @@ const BotConfig = telegram_api.BotConfig;
 /// Shared state for streaming — module-level, accessible from main + worker threads
 var stream_state = claude_stream.StreamState{};
 
+/// Runtime state — model selection, persists across commands within a bot run
+var bot_state = handlers.BotState{};
+
 /// Run the bot loop: poll Telegram, parse commands, dispatch handlers.
 /// Never returns (infinite loop). Main thread stays responsive while
 /// worker thread handles Claude streaming.
@@ -19,9 +22,9 @@ pub fn run(allocator: std.mem.Allocator, config: BotConfig) void {
     var last_update_id: i64 = 0;
 
     // Announce startup
-    telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xf0\x9f\xa4\x96 TRI BOT v2.0 online! Send /help for commands.");
+    telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xf0\x9f\xa4\x96 TRI BOT v3.0 online! Send /help for commands.");
 
-    std.debug.print("[tri-bot] Started (Phase 2: streaming). Polling Telegram...\n", .{});
+    std.debug.print("[tri-bot] Started (Phase 2.5: streaming + sessions). Polling Telegram...\n", .{});
 
     while (true) {
         const body = telegram_api.getUpdates(allocator, config.bot_token, last_update_id + 1) orelse {
@@ -87,11 +90,23 @@ fn processUpdates(allocator: std.mem.Allocator, config: BotConfig, body: []const
     }
 }
 
+/// Helper: check if busy + spawn streaming worker thread.
+fn spawnStreaming(allocator: std.mem.Allocator, config: BotConfig, opts: claude_stream.StreamOpts) void {
+    stream_state.is_busy.store(true, .release);
+    _ = std.Thread.spawn(.{}, claude_stream.runStreaming, .{ allocator, config, opts, &stream_state }) catch {
+        stream_state.is_busy.store(false, .release);
+        allocator.free(opts.args);
+        if (opts.resume_id) |rid| allocator.free(rid);
+        telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9d\x8c Failed to spawn worker thread");
+        return;
+    };
+}
+
 fn dispatch(allocator: std.mem.Allocator, config: BotConfig, cmd: command_parser.Command) void {
     if (std.mem.eql(u8, cmd.name, "help")) {
         handlers.handleHelp(allocator, config);
     } else if (std.mem.eql(u8, cmd.name, "ask")) {
-        // Phase 2: streaming /ask via worker thread
+        // Streaming /ask via worker thread
         if (cmd.args.len == 0) {
             telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9a\xa0 Usage: /ask <question>");
             return;
@@ -100,34 +115,58 @@ fn dispatch(allocator: std.mem.Allocator, config: BotConfig, cmd: command_parser
             telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x8f\xb3 Already processing. Send /stop first.");
             return;
         }
-        // Dupe args — they point into getUpdates body which will be freed
         const args_owned = allocator.dupe(u8, cmd.args) catch return;
-        stream_state.is_busy.store(true, .release);
-        _ = std.Thread.spawn(.{}, claude_stream.runStreaming, .{ allocator, config, args_owned, false, &stream_state }) catch {
-            stream_state.is_busy.store(false, .release);
-            allocator.free(args_owned);
-            telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9d\x8c Failed to spawn worker thread");
-            return;
-        };
+        spawnStreaming(allocator, config, .{
+            .args = args_owned,
+            .model = bot_state.getModel(),
+        });
     } else if (std.mem.eql(u8, cmd.name, "continue")) {
-        // Phase 2: streaming /continue via worker thread
+        // Streaming /continue via worker thread
         if (stream_state.is_busy.load(.acquire)) {
             telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x8f\xb3 Already processing. Send /stop first.");
             return;
         }
         const args_owned = allocator.dupe(u8, cmd.args) catch return;
-        stream_state.is_busy.store(true, .release);
-        _ = std.Thread.spawn(.{}, claude_stream.runStreaming, .{ allocator, config, args_owned, true, &stream_state }) catch {
-            stream_state.is_busy.store(false, .release);
-            allocator.free(args_owned);
-            telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9d\x8c Failed to spawn worker thread");
+        spawnStreaming(allocator, config, .{
+            .args = args_owned,
+            .use_continue = true,
+            .model = bot_state.getModel(),
+        });
+    } else if (std.mem.eql(u8, cmd.name, "resume")) {
+        // Streaming /resume <id> via worker thread
+        if (cmd.args.len == 0) {
+            telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9a\xa0 Usage: /resume <session-id>");
+            return;
+        }
+        if (stream_state.is_busy.load(.acquire)) {
+            telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x8f\xb3 Already processing. Send /stop first.");
+            return;
+        }
+        // Extract session ID (first word of args)
+        const id_end = std.mem.indexOf(u8, cmd.args, " ") orelse cmd.args.len;
+        const resume_id = allocator.dupe(u8, cmd.args[0..id_end]) catch return;
+        // Remaining text after ID is the prompt (if any)
+        const prompt_start = if (id_end < cmd.args.len) id_end + 1 else id_end;
+        const prompt = allocator.dupe(u8, cmd.args[prompt_start..]) catch {
+            allocator.free(resume_id);
             return;
         };
+        spawnStreaming(allocator, config, .{
+            .args = prompt,
+            .resume_id = resume_id,
+            .model = bot_state.getModel(),
+        });
+    } else if (std.mem.eql(u8, cmd.name, "model")) {
+        // Blocking: set/show model
+        handlers.handleModel(allocator, config, cmd.args, &bot_state);
+    } else if (std.mem.eql(u8, cmd.name, "sessions")) {
+        // Blocking: list sessions
+        handlers.handleSessions(allocator, config);
     } else if (std.mem.eql(u8, cmd.name, "status")) {
-        // Status stays blocking (short query, no streaming needed)
+        // Blocking: project status
         handlers.handleStatus(allocator, config);
     } else if (std.mem.eql(u8, cmd.name, "stop")) {
-        // Phase 2: /stop kills active Claude process
+        // Kill active Claude process
         claude_stream.stopProcess(allocator, config, &stream_state);
     } else if (cmd.name.len > 0) {
         var buf: [256]u8 = undefined;

--- a/tools/mcp/trinity_mcp/bot/claude_stream.zig
+++ b/tools/mcp/trinity_mcp/bot/claude_stream.zig
@@ -14,23 +14,33 @@ pub const StreamState = struct {
     active_pid: std.atomic.Value(i32) = std.atomic.Value(i32).init(0),
 };
 
+/// Options for streaming — covers /ask, /continue, and /resume.
+pub const StreamOpts = struct {
+    args: []const u8, // prompt text (caller-owned, freed by worker)
+    use_continue: bool = false,
+    resume_id: ?[]const u8 = null, // session ID for --resume
+    model: ?[]const u8 = null, // model override (pointer to BotState buffer)
+};
+
 /// Worker thread entry point: spawn claude, stream output, send drafts.
 /// Called via std.Thread.spawn() from bot_loop dispatch.
 pub fn runStreaming(
     allocator: std.mem.Allocator,
     config: BotConfig,
-    args_owned: []const u8,
-    use_continue: bool,
+    opts: StreamOpts,
     state: *StreamState,
 ) void {
     defer {
         state.active_pid.store(0, .release);
         state.is_busy.store(false, .release);
-        allocator.free(args_owned);
+        allocator.free(opts.args);
+        if (opts.resume_id) |rid| allocator.free(rid);
     }
 
     // Notify user
-    if (use_continue) {
+    if (opts.resume_id != null) {
+        telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xf0\x9f\x94\x84 TRI resuming session...");
+    } else if (opts.use_continue) {
         telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xf0\x9f\x94\x84 TRI streaming...");
     } else {
         telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xf0\x9f\xa7\xa0 TRI streaming...");
@@ -40,20 +50,31 @@ pub fn runStreaming(
     var turns_buf: [16]u8 = undefined;
     const turns_str = std.fmt.bufPrint(&turns_buf, "{d}", .{config.max_turns}) catch "10";
 
-    // Build argv dynamically based on args and --continue flag
-    var argv_buf: [12][]const u8 = undefined;
+    // Build argv dynamically based on opts
+    var argv_buf: [16][]const u8 = undefined;
     var argc: usize = 0;
 
     argv_buf[argc] = "claude";
     argc += 1;
-    if (args_owned.len > 0) {
+    if (opts.args.len > 0) {
         argv_buf[argc] = "-p";
         argc += 1;
-        argv_buf[argc] = args_owned;
+        argv_buf[argc] = opts.args;
         argc += 1;
     }
-    if (use_continue) {
+    if (opts.resume_id) |rid| {
+        argv_buf[argc] = "--resume";
+        argc += 1;
+        argv_buf[argc] = rid;
+        argc += 1;
+    } else if (opts.use_continue) {
         argv_buf[argc] = "--continue";
+        argc += 1;
+    }
+    if (opts.model) |model| {
+        argv_buf[argc] = "--model";
+        argc += 1;
+        argv_buf[argc] = model;
         argc += 1;
     }
     argv_buf[argc] = "--output-format";

--- a/tools/mcp/trinity_mcp/bot/handlers.zig
+++ b/tools/mcp/trinity_mcp/bot/handlers.zig
@@ -2,8 +2,26 @@
 // Each handler: receives args + config, runs claude CLI, sends result to Telegram
 const std = @import("std");
 const telegram_api = @import("telegram_api.zig");
+const json_utils = @import("json_utils.zig");
 
 const BotConfig = telegram_api.BotConfig;
+
+/// Runtime state that persists across commands within a bot run.
+pub const BotState = struct {
+    model_buf: [64]u8 = undefined,
+    model_len: usize = 0,
+
+    pub fn getModel(self: *const BotState) ?[]const u8 {
+        if (self.model_len == 0) return null;
+        return self.model_buf[0..self.model_len];
+    }
+
+    pub fn setModel(self: *BotState, name: []const u8) void {
+        const len = @min(name.len, self.model_buf.len);
+        @memcpy(self.model_buf[0..len], name[0..len]);
+        self.model_len = len;
+    }
+};
 
 /// /help — Send list of available commands
 pub fn handleHelp(allocator: std.mem.Allocator, config: BotConfig) void {
@@ -11,12 +29,15 @@ pub fn handleHelp(allocator: std.mem.Allocator, config: BotConfig) void {
         "\xf0\x9f\xa4\x96 TRI BOT \xe2\x80\x94 Claude Code Remote Control\n" ++
         "\n" ++
         "/ask <question> \xe2\x80\x94 Ask Claude (streaming)\n" ++
-        "/continue [question] \xe2\x80\x94 Continue session (streaming)\n" ++
+        "/continue [msg] \xe2\x80\x94 Continue session\n" ++
+        "/resume <id> \xe2\x80\x94 Resume session by ID\n" ++
+        "/sessions \xe2\x80\x94 List recent sessions\n" ++
+        "/model <name> \xe2\x80\x94 Set Claude model\n" ++
         "/status \xe2\x80\x94 Project status\n" ++
-        "/stop \xe2\x80\x94 Stop running Claude process\n" ++
+        "/stop \xe2\x80\x94 Stop running process\n" ++
         "/help \xe2\x80\x94 This message\n" ++
         "\n" ++
-        "Phase 3: /resume, /model, /board, /pr, /worktree";
+        "Phase 3: /board, /pr, /worktree";
     telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, help_text);
 }
 
@@ -118,4 +139,105 @@ pub fn handleStatus(allocator: std.mem.Allocator, config: BotConfig) void {
     }
 
     telegram_api.sendLongMessage(allocator, config, result.stdout);
+}
+
+/// /model <name> — Set Claude model for subsequent requests.
+pub fn handleModel(allocator: std.mem.Allocator, config: BotConfig, args: []const u8, bot_state: *BotState) void {
+    if (args.len == 0) {
+        // Show current model
+        if (bot_state.getModel()) |model| {
+            var buf: [256]u8 = undefined;
+            telegram_api.sendFmt(allocator, config.bot_token, config.chat_id, &buf, "\xf0\x9f\xa4\x96 Current model: {s}", .{model});
+        } else {
+            telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xf0\x9f\xa4\x96 Model: default (no override)");
+        }
+        return;
+    }
+
+    if (args.len > 64) {
+        telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9a\xa0 Model name too long (max 64 chars)");
+        return;
+    }
+
+    bot_state.setModel(args);
+    var buf: [256]u8 = undefined;
+    telegram_api.sendFmt(allocator, config.bot_token, config.chat_id, &buf, "\xe2\x9c\x85 Model set: {s}", .{args});
+}
+
+/// /sessions — List recent Claude sessions.
+pub fn handleSessions(allocator: std.mem.Allocator, config: BotConfig) void {
+    telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xf0\x9f\x93\x8b Fetching sessions...");
+
+    const result = std.process.Child.run(.{
+        .allocator = allocator,
+        .argv = &.{ "claude", "sessions", "list", "--json" },
+        .cwd = config.project_root,
+        .max_output_bytes = 128 * 1024,
+    }) catch |err| {
+        var err_buf: [256]u8 = undefined;
+        telegram_api.sendFmt(allocator, config.bot_token, config.chat_id, &err_buf, "\xe2\x9d\x8c Sessions error: {s}", .{@errorName(err)});
+        return;
+    };
+    defer allocator.free(result.stdout);
+    defer allocator.free(result.stderr);
+
+    if (result.stdout.len == 0) {
+        telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9a\xa0 No sessions found");
+        return;
+    }
+
+    // Format sessions: extract id + summary from JSON array
+    var out_buf: std.ArrayList(u8) = .empty;
+    defer out_buf.deinit(allocator);
+
+    out_buf.appendSlice(allocator, "\xf0\x9f\x93\x8b Recent sessions:\n") catch return;
+    formatSessions(allocator, &out_buf, result.stdout);
+
+    if (out_buf.items.len > 20) {
+        telegram_api.sendLongMessage(allocator, config, out_buf.items);
+    } else {
+        telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9a\xa0 Could not parse sessions");
+    }
+}
+
+/// Parse JSON session list and append formatted entries to output buffer.
+fn formatSessions(allocator: std.mem.Allocator, out: *std.ArrayList(u8), json: []const u8) void {
+    var count: usize = 0;
+    var pos: usize = 0;
+    const id_needle = "\"session_id\":\"";
+
+    while (pos < json.len and count < 10) {
+        const idx = std.mem.indexOfPos(u8, json, pos, id_needle) orelse break;
+        const id_start = idx + id_needle.len;
+        const id_end = std.mem.indexOfPos(u8, json, id_start, "\"") orelse break;
+        const session_id = json[id_start..id_end];
+
+        // Try to find summary near this session entry
+        const block_end = std.mem.indexOfPos(u8, json, id_end, id_needle) orelse json.len;
+        const block = json[idx..block_end];
+        const summary = json_utils.extractString(block, "summary") orelse
+            json_utils.extractString(block, "name") orelse "(no summary)";
+
+        count += 1;
+        var num_buf: [4]u8 = undefined;
+        const num_str = std.fmt.bufPrint(&num_buf, "{d}", .{count}) catch "?";
+        out.appendSlice(allocator, num_str) catch {};
+        out.appendSlice(allocator, ". ") catch {};
+        // Show short ID (first 8 chars or full if shorter)
+        const short_id = if (session_id.len > 8) session_id[0..8] else session_id;
+        out.appendSlice(allocator, short_id) catch {};
+        out.appendSlice(allocator, " \xe2\x80\x94 ") catch {};
+        // Truncate summary to 60 chars
+        const max_sum: usize = 60;
+        const sum_display = if (summary.len > max_sum) summary[0..max_sum] else summary;
+        out.appendSlice(allocator, sum_display) catch {};
+        if (summary.len > max_sum) out.appendSlice(allocator, "...") catch {};
+        out.appendSlice(allocator, "\n") catch {};
+
+        pos = block_end;
+    }
+
+    if (count == 0) {
+        out.appendSlice(allocator, "(no sessions found)\n") catch {};
+    }
 }


### PR DESCRIPTION
## Summary

- `/model <name>` — set Claude model for subsequent requests, persists across commands in `BotState`
- `/resume <id> [msg]` — resume previous session by ID via streaming worker thread
- `/sessions` — list recent Claude sessions with IDs and summaries
- `StreamOpts` struct replaces positional args in `runStreaming()` — cleaner, extensible
- `spawnStreaming()` helper DRYs up thread spawn + error handling in `bot_loop.zig`
- `BotState` struct in `handlers.zig` — 64-byte model buffer, persists within bot run

## Files changed (3, +214/-32)

| File | Change |
|------|--------|
| `bot_loop.zig` | Added `bot_state`, `spawnStreaming()` helper, dispatch for `/model`, `/resume`, `/sessions` |
| `claude_stream.zig` | `StreamOpts` struct with `model`, `resume_id` fields; argv builder supports `--model` and `--resume` |
| `handlers.zig` | `BotState` struct, `handleModel()`, `handleSessions()` with JSON parsing, updated help text |

## Test plan

- [ ] `/model claude-sonnet-4-20250514` → confirms model set
- [ ] `/model` (no args) → shows current model
- [ ] `/ask` after `/model` → uses selected model
- [ ] `/sessions` → lists recent sessions with short IDs
- [ ] `/resume <id>` → resumes session via streaming
- [ ] `/resume <id> follow up question` → resumes with prompt
- [ ] Bot stays responsive during streaming (/stop works)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)