### PR TITLE
fix(cli): prevent use-after-free in GitHub client

### DIFF
--- a/.trinity/protocol/2026-03-10.jsonl
+++ b/.trinity/protocol/2026-03-10.jsonl
@@ -7,3 +7,5 @@
 {"ts":1773139815,"action":"issue_close","issue":86,"agent":"unknown","ok":true}
 {"ts":1773139821,"action":"issue_decompose","issue":86,"agent":"ralph","ok":true}
 {"ts":1773140195,"action":"issue_decompose","issue":75,"agent":"ralph","ok":true}
+{"ts":1773140230,"action":"issue_comment","issue":88,"agent":"ralph","ok":true}
+{"ts":1773140248,"action":"issue_decompose","issue":75,"agent":"ralph","ok":true}


### PR DESCRIPTION
## Summary
- `detectOwnerRepo` freed the git stdout buffer while `OwnerRepo` slices still pointed into it
- Fixed by duping `owner` and `repo` strings so they outlive the buffer
- Discovered during first real Protocol v2 test (`tri issue decompose 75`)

## Test plan
- [x] `tri issue decompose 75 --template standard --agent ralph` — creates 5 sub-issues successfully
- [x] No more SIGSEGV on real API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)