### PR TITLE
fix(cloud): buffer size increase, CLAUDE.md.agent to .gitignore (#136)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,3 +258,6 @@ hslm-train/
 --output
 --output/
 data/checkpoints_v3/
+
+# Claude agent config (local)
+CLAUDE.md.agent

--- a/tools/mcp/trinity_mcp/cloud_monitor.zig
+++ b/tools/mcp/trinity_mcp/cloud_monitor.zig
@@ -274,7 +274,7 @@ fn handleConnection(stream: net.Stream) !void {
 
     // Route: GET /api/agents — list agent statuses
     if (std.mem.startsWith(u8, request, "GET /api/agents")) {
-        var buf: [8192]u8 = undefined;
+        var buf: [16384]u8 = undefined;
         const json = getStatusJson(&buf);
         try sendHttpResponse(stream, "200 OK", "application/json", json);
         return;


### PR DESCRIPTION
Closes #136

## Changes
- Increased buffer size in /api/agents route from 8192 to 16384 bytes
- Added CLAUDE.md.agent to .gitignore

## Notes
Other bugs mentioned in issue (ISO8601 parse, bounds check, dead code) are not present in the current code - they may have already been fixed in a later commit or were never introduced. This PR fixes the issues that were actually found in the codebase.