### PR TITLE
fix(bot): replace catch unreachable with proper error handling in claude_stream.zig

### DIFF
--- a/tools/mcp/trinity_mcp/bot/claude_stream.zig
+++ b/tools/mcp/trinity_mcp/bot/claude_stream.zig
@@ -64,7 +64,11 @@ pub fn runStreaming(
     };
     defer allocator.free(api_url);
 
-    const uri = std.Uri.parse(api_url) catch unreachable;
+    const uri = std.Uri.parse(api_url) catch |err| {
+        std.log.err("Invalid API URL: {s} — {}", .{ api_url, err });
+        telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9d\x8c Invalid API URL");
+        return;
+    };
 
     var req = client.request(.POST, uri, .{
         .extra_headers = &.{


### PR DESCRIPTION
## Summary
- Replaced unsafe `catch unreachable` on URI parsing (line 67) with proper error handling
- Now logs the error with `std.log.err` and returns gracefully with a Telegram notification
- The API URL is built dynamically from environment variables (`config.api_base_url`) and could be malformed

## Changes
- `tools/mcp/trinity_mcp/bot/claude_stream.zig` — line 67

## Acceptance Criteria
- [x] `zig ast-check` passes (syntax valid)
- [x] `zig fmt` passes
- [x] No `catch unreachable` on URI parsing

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)