### PR TITLE
fix(ralph): replace catch unreachable with try in ralph_orchestrator.zig init

### DIFF
--- a/src/tri/ralph_orchestrator.zig
+++ b/src/tri/ralph_orchestrator.zig
@@ -145,7 +145,7 @@ pub const RalphOrchestrator = struct {
                 .wake_time = current_time + @as(i64, @intCast(config.wake_interval_sec)),
                 .next_wake_interval = config.wake_interval_sec,
             },
-            .tasks = std.ArrayList(RalphTask).initCapacity(allocator, 0) catch unreachable,
+            .tasks = try std.ArrayList(RalphTask).initCapacity(allocator, 0),
         };
     }
 


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with `try` on line 148 of `src/tri/ralph_orchestrator.zig`
- The enclosing `init()` function already returns an error union (`!RalphOrchestrator`), so allocation errors will now properly propagate instead of causing a crash

## Test plan
- [x] `zig fmt` passes
- [x] `zig ast-check` passes on modified file
- [x] No `catch unreachable` on ArrayList init

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)