### PR TITLE
fix(ws): replace catch unreachable with proper error handling

### DIFF
--- a/src/tri/websocket/intelligence_server.zig
+++ b/src/tri/websocket/intelligence_server.zig
@@ -204,11 +204,11 @@ pub const WSClient = struct {
 
     mutex: std.Thread.Mutex,
 
-    pub fn init(allocator: Allocator, stream: net.Stream) WSClient {
+    pub fn init(allocator: Allocator, stream: net.Stream) !WSClient {
         return .{
             .allocator = allocator,
             .stream = stream,
-            .address = stream.address catch unreachable,
+            .address = try stream.address,
             .connected = true,
             .mutex = std.Thread.Mutex{},
         };
@@ -370,7 +370,12 @@ pub const WSServer = struct {
                     stream.close();
                     continue;
                 };
-                client_ptr.* = WSClient.init(server.allocator, stream);
+                client_ptr.* = WSClient.init(server.allocator, stream) catch |err| {
+                    stdout.print("Failed to get client address: {}\n", .{err}) catch {};
+                    server.allocator.destroy(client_ptr);
+                    stream.close();
+                    continue;
+                };
 
                 server.mutex.lock();
                 server.clients.append(server.allocator, client_ptr) catch {


### PR DESCRIPTION
## Summary
- Replaced `catch unreachable` with proper error handling in `WSClient.init`
- Changed function signature to return `!WSClient` for error propagation
- Updated `listenerLoop` to handle errors gracefully with logging and cleanup

## Changes
1. **Line 207**: Changed `init` signature from `WSClient` to `!WSClient`
2. **Line 211**: Replaced `stream.address catch unreachable` with `try stream.address`
3. **Lines 373-378**: Added error handling in `listenerLoop` with proper logging and resource cleanup

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)