### PR TITLE
refactor(faculty): extract hardcoded paths to constants in faculty_board.zig

### DIFF
--- a/src/tri/faculty_board.zig
+++ b/src/tri/faculty_board.zig
@@ -23,6 +23,8 @@ const Path = three_paths.Path;
 const PREV_PATH = ".trinity/faculty_prev.dat";
 const TG_HASH_PATH = ".trinity/faculty_tg_hash.dat";
 const AGENT_CMD_LOG = ".trinity/agent_commands.log";
+const REGEN_REPORT = "specs/REGENERATION_REPORT.md";
+const MU_LEARNING_DB = ".trinity/mu/learning_db.json";
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // DATA COLLECTION
@@ -496,7 +498,7 @@ fn countBinaries() u8 {
 const RegenStats = struct { pass: u16, total: u16 };
 
 fn parseRegenReport(allocator: Allocator) RegenStats {
-    const content = std.fs.cwd().readFileAlloc(allocator, "specs/REGENERATION_REPORT.md", 256 * 1024) catch
+    const content = std.fs.cwd().readFileAlloc(allocator, REGEN_REPORT, 256 * 1024) catch
         return .{ .pass = 0, .total = 0 };
     defer allocator.free(content);
 
@@ -551,7 +553,7 @@ fn countOpenIssues(allocator: Allocator) u16 {
 }
 
 fn countMuPatterns(allocator: Allocator) u16 {
-    const content = std.fs.cwd().readFileAlloc(allocator, ".trinity/mu/learning_db.json", 64 * 1024) catch
+    const content = std.fs.cwd().readFileAlloc(allocator, MU_LEARNING_DB, 64 * 1024) catch
         return 0;
     defer allocator.free(content);
     // Count pattern entries


### PR DESCRIPTION
## Summary
- Extract `REGEN_REPORT` constant for `"specs/REGENERATION_REPORT.md"`
- Extract `MU_LEARNING_DB` constant for `".trinity/mu/learning_db.json"`
- Replace string literals in `parseRegenReport()` and `countMuPatterns()` with these constants

## Test Plan
- [x] `zig build libvsa` compiles successfully
- [x] All 37 tests pass including `parseRegenReport handles missing file`
- [x] Constants defined at module level with existing constants

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)