### PR TITLE
fix(history): add error logging to silent catch {} handlers

### DIFF
--- a/src/tri/tri_history.zig
+++ b/src/tri/tri_history.zig
@@ -61,7 +61,9 @@ pub const History = struct {
         }
 
         // Save to file
-        self.save() catch {};
+        self.save() catch |err| {
+            std.log.debug("history save: {s}", .{@errorName(err)});
+        };
     }
 
     /// Navigate to previous command
@@ -252,7 +254,9 @@ pub const ReplHistory = struct {
 
     /// Load history from file
     pub fn load(self: *ReplHistory) !void {
-        self.history.load() catch {};
+        self.history.load() catch |err| {
+            std.log.debug("history load: {s}", .{@errorName(err)});
+        };
     }
 
     /// Save current input and clear
@@ -312,7 +316,9 @@ pub const ReplHistory = struct {
 
     /// Save history before exit
     pub fn saveBeforeExit(self: *ReplHistory) void {
-        self.history.save() catch {};
+        self.history.save() catch |err| {
+            std.log.debug("history save: {s}", .{@errorName(err)});
+        };
     }
 };
 


### PR DESCRIPTION
## Summary
- Replace 3 silent `catch {}` handlers with proper error logging in `src/tri/tri_history.zig`
- Use `std.log.debug` for consistency as specified in the issue

## Changes
- `History.add()`: log save errors instead of silently swallowing
- `ReplHistory.load()`: log load errors instead of silently swallowing  
- `ReplHistory.saveBeforeExit()`: log save errors instead of silently swallowing

## Test plan
- [x] `zig test src/tri/tri_history.zig` — All 5 tests pass
- [x] No empty `catch {}` handlers remaining in file
- [x] Each catch logs error name via `std.log.debug`

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)