### PR TITLE
fix(state): add missing child.deinit() in runProcessInherit

### DIFF
--- a/src/tri/tri_state.zig
+++ b/src/tri/tri_state.zig
@@ -33,6 +33,7 @@ pub fn runProcessAndCapture(allocator: std.mem.Allocator, argv: []const []const 
 /// Run a subprocess, inherit stdio, return exit code
 pub fn runProcessInherit(allocator: std.mem.Allocator, argv: []const []const u8) !u8 {
     var child = std.process.Child.init(argv, allocator);
+    defer child.deinit();
     child.stdout_behavior = .Inherit;
     child.stderr_behavior = .Inherit;
     _ = try child.spawn();


### PR DESCRIPTION
## Summary
- Add `defer child.deinit()` after `std.process.Child.init()` in `runProcessInherit()` function
- Fixes process resource leak identified in issue #165

## Changes
- `src/tri/tri_state.zig`: Added `defer child.deinit();` on line 36

## Test plan
- [x] `zig fmt` passes on modified file
- [ ] Full build passes (pre-existing issues in other files)

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)