### PR TITLE
fix(mcp-client): add child.deinit() in spawn error path

### DIFF
--- a/src/tri-api/mcp_client.zig
+++ b/src/tri-api/mcp_client.zig
@@ -57,6 +57,7 @@ pub const McpManager = struct {
 
         child.spawn() catch |err| {
             std.debug.print("[mcp] Failed to spawn {s}: {s}\n", .{ name, @errorName(err) });
+            child.deinit();
             return 0;
         };
 


### PR DESCRIPTION
## Summary
- Fix resource leak in `src/tri-api/mcp_client.zig` where `child.deinit()` was not called when `child.spawn()` failed
- Added `child.deinit()` before the early return in the spawn error path (line 60)

## Changes
- `src/tri-api/mcp_client.zig`: Added `child.deinit()` call in the spawn error handler

## Test Plan
- [x] `zig fmt src/tri-api/mcp_client.zig` passes (syntax valid)
- [x] `zig ast-check src/tri-api/mcp_client.zig` passes
- [x] Code change follows Zig memory management pattern (explicit cleanup on error)

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)