### PR TITLE
fix(orchestrator): add bounds check for offset in cloud_orchestrator.zig parsing

### DIFF
--- a/src/tri/cloud_orchestrator.zig
+++ b/src/tri/cloud_orchestrator.zig
@@ -283,7 +283,7 @@ fn loadState() void {
         entry.service_id_len = @min(sid.len, 128);
         @memcpy(entry.service_id[0..entry.service_id_len], sid[0..entry.service_id_len]);
         agent_count += 1;
-        offset = sid_end + 1;
+        offset = @min(sid_end + 1, content.len);
     }
 }
 


### PR DESCRIPTION
## Summary
- Added bounds check `@min(sid_end + 1, content.len)` in the JSON parsing loop to prevent out-of-bounds memory access

## Changes
- In `src/tri/cloud_orchestrator.zig` line 286, changed `offset = sid_end + 1` to `offset = @min(sid_end + 1, content.len)`

## Root Cause
When parsing JSON to find issue/service_id pairs, if `sid_end` equals `content.len`, then `sid_end + 1` would be out-of-bounds. This could cause undefined behavior in the next iteration's `indexOfPos` call.

## Test Plan
- [x] Code compiles (no new errors introduced)
- [x] `zig fmt` passes

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)