### PR TITLE
fix(cloud-tools): add defer free for stdout allocation

### DIFF
--- a/tools/mcp/trinity_mcp/cloud_tools.zig
+++ b/tools/mcp/trinity_mcp/cloud_tools.zig
@@ -70,6 +70,7 @@ fn runTriCloud(buf: *[MAX_OUTPUT]u8, args: []const []const u8) []const u8 {
     const stdout = child.stdout.?.readToEndAlloc(std.heap.page_allocator, MAX_OUTPUT) catch {
         return copyToBuf(buf, "Error: Failed to read output");
     };
+    defer std.heap.page_allocator.free(stdout);
 
     _ = child.wait() catch {};
 


### PR DESCRIPTION
## Summary
- Add `defer std.heap.page_allocator.free(stdout)` after `readToEndAlloc` in `runTriCloud()` function
- Fixes memory leak that occurred on every MCP tool call in `cloud_tools.zig`

## Test plan
- [x] `zig fmt` passes on edited file
- [x] Code change is minimal (1 line addition)
- [x] Follows Zig memory management best practices

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)