### PR TITLE
fix(jobs): add error logging to child.kill catch block

### DIFF
--- a/src/tri/job_system.zig
+++ b/src/tri/job_system.zig
@@ -572,7 +572,9 @@ pub const Job = struct {
     /// Deinitialize job
     fn deinit(self: *Job) void {
         if (self.child_process) |*child| {
-            _ = child.kill() catch {};
+            _ = child.kill() catch |err| {
+                std.log.warn("failed to kill child process: {s}", .{@errorName(err)});
+            };
             _ = child.wait() catch {};
         }
 


### PR DESCRIPTION
## Summary
- Add proper error logging in `src/tri/job_system.zig` line 575
- Replace silently ignored `catch {}` with `catch |err| { std.log.warn(...) }`
- Error is now logged when killing a child process fails during job cleanup

## Test plan
- [x] Code change matches the issue specification exactly
- [x] `zig fmt src/` passes (no formatting issues)
- [ ] Build passes (pre-existing errors in unrelated files)

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)