### PR TITLE
fix(research): add error logging to catch {} handlers in tri_research.zig

### DIFF
--- a/src/tri/tri_research.zig
+++ b/src/tri/tri_research.zig
@@ -260,10 +260,14 @@ fn runPerplexityQuery(allocator: std.mem.Allocator, args: []const []const u8) !v
 fn cacheAnswer(allocator: std.mem.Allocator, path: []const u8, answer: []const u8) !void {
     _ = allocator;
     if (path.len == 0) return;
-    std.fs.cwd().makePath(CACHE_DIR) catch {};
+    std.fs.cwd().makePath(CACHE_DIR) catch |err| {
+        std.log.warn("failed to create cache dir: {s}", .{@errorName(err)});
+    };
     const file = std.fs.cwd().createFile(path, .{}) catch return;
     defer file.close();
-    file.writeAll(answer) catch {};
+    file.writeAll(answer) catch |err| {
+        std.log.warn("failed to write cache: {s}", .{@errorName(err)});
+    };
 }
 
 /// Offline pattern matching for common Zig errors


### PR DESCRIPTION
## Summary
- Replace silent `catch {}` error handlers with proper logging in `cacheAnswer()`
- `makePath()` now logs warning on cache directory creation failure
- `writeAll()` now logs warning on cache write failure

## Changes
- Line 263: `catch {}` → `catch |err| { std.log.warn(...) }`
- Line 266: `catch {}` → `catch |err| { std.log.warn(...) }`

## Test plan
- [x] `zig ast-check src/tri/tri_research.zig` passes
- [x] No more empty `catch {}` in file (grep verified)

Closes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)