### PR TITLE
fix(cmd): replace catch {} with error logging in command_interface.zig

### DIFF
--- a/src/tri/command_interface.zig
+++ b/src/tri/command_interface.zig
@@ -176,7 +176,9 @@ pub fn listCategory(category: CommandCategory) []const CommandMetadata {
 
     for (registry.items) |cmd| {
         if (std.mem.eql(u8, cmd.category, cat_str)) {
-            result.append(cmd) catch {};
+            result.append(cmd) catch |err| {
+                std.log.warn("command append failed: {s}", .{@errorName(err)});
+            };
         }
     }
 
@@ -244,7 +246,9 @@ pub fn listMcpTools() []const McpToolSchema {
 
     for (registry.items) |cmd| {
         if (cmd.mcp_enabled) {
-            result.append(toMcpTool(cmd)) catch {};
+            result.append(toMcpTool(cmd)) catch |err| {
+                std.log.warn("MCP tool append failed: {s}", .{@errorName(err)});
+            };
         }
     }
 


### PR DESCRIPTION
## Summary
- Replace silent `catch {}` error swallowing with proper `std.log.warn()` logging in `listCategory()` (line 179) and `listMcpTools()` (line 247)
- OOM failures from ArrayList append operations are now logged instead of silently ignored

## Changes
- `src/tri/command_interface.zig`: Two locations updated with error logging pattern

## Acceptance Criteria Met
- [x] `zig fmt` passes
- [x] No empty `catch {}` in this file
- [x] Proper error logging with `std.log.warn()`

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)