### PR TITLE
fix(utils): replace remaining catch {} in tri_utils.zig interactive mode

### DIFF
--- a/src/tri/tri_utils.zig
+++ b/src/tri/tri_utils.zig
@@ -1482,8 +1482,12 @@ pub fn runCodeCommand(state: *CLIState, args: []const []const u8) void {
                     }
                 }
 
-                combined.appendSlice(state.allocator, sacred_ctx) catch {};
-                combined.appendSlice(state.allocator, prompt) catch {};
+                combined.appendSlice(state.allocator, sacred_ctx) catch |err| {
+                    std.log.debug("append sacred context: {s}", .{@errorName(err)});
+                };
+                combined.appendSlice(state.allocator, prompt) catch |err| {
+                    std.log.debug("append prompt: {s}", .{@errorName(err)});
+                };
                 enhanced_prompt = combined.toOwnedSlice(state.allocator) catch null;
             } else |_| {}
         }
@@ -1600,8 +1604,12 @@ pub fn runChatCommand(state: *CLIState, args: []const []const u8) void {
                         }
                     }
 
-                    combined.appendSlice(state.allocator, sacred_ctx) catch {};
-                    combined.appendSlice(state.allocator, msg) catch {};
+                    combined.appendSlice(state.allocator, sacred_ctx) catch |err| {
+                        std.log.debug("append sacred context: {s}", .{@errorName(err)});
+                    };
+                    combined.appendSlice(state.allocator, msg) catch |err| {
+                        std.log.debug("append message: {s}", .{@errorName(err)});
+                    };
                     enhanced_msg = combined.toOwnedSlice(state.allocator) catch null;
                 } else |_| {}
             }
@@ -1629,7 +1637,9 @@ pub fn runChatCommand(state: *CLIState, args: []const []const u8) void {
     } else {
         // Interactive chat mode
         state.mode = .Chat;
-        runInteractiveMode(state) catch {};
+        runInteractiveMode(state) catch |err| {
+            std.log.err("interactive mode failed: {s}", .{@errorName(err)});
+        };
     }
 }
 
@@ -1776,7 +1786,9 @@ pub fn runSWECommand(state: *CLIState, task_type: trinity_swe.SWETaskType, args:
             }
 
             // Append sacred context
-            combined_buf.appendSlice(state.allocator, sacred_ctx) catch {};
+            combined_buf.appendSlice(state.allocator, sacred_ctx) catch |err| {
+                std.log.debug("append sacred context: {s}", .{@errorName(err)});
+            };
 
             // Append codebase context if available
             if (codebase_ctx) |ctx| {


### PR DESCRIPTION
## Summary
- Replace empty `catch {}` blocks with proper error logging using `std.log.debug` and `std.log.err` at the specified lines in `src/tri/tri_utils.zig`
- Lines fixed: 1485, 1486, 1603, 1604, 1632, and 1779

## Changes
| Line | Before | After |
|------|--------|-------|
| 1485 | `catch {}` | `catch \|err\| { std.log.debug("append sacred context: {s}", .{@errorName(err)}); }` |
| 1486 | `catch {}` | `catch \|err\| { std.log.debug("append prompt: {s}", .{@errorName(err)}); }` |
| 1603 | `catch {}` | `catch \|err\| { std.log.debug("append sacred context: {s}", .{@errorName(err)}); }` |
| 1604 | `catch {}` | `catch \|err\| { std.log.debug("append message: {s}", .{@errorName(err)}); }` |
| 1632 | `catch {}` | `catch \|err\| { std.log.err("interactive mode failed: {s}", .{@errorName(err)}); }` |
| 1779 | `catch {}` | `catch \|err\| { std.log.debug("append sacred context: {s}", .{@errorName(err)}); }` |

## Acceptance Criteria
- [x] `zig fmt src/` passes
- [x] `zig ast-check src/tri/tri_utils.zig` passes
- [x] No empty `catch {}` remaining in these lines

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)