### PR TITLE
fix(node): replace empty catch {} with error logging in trinity_node modules

### DIFF
--- a/src/trinity_node/bandwidth_aggregator.zig
+++ b/src/trinity_node/bandwidth_aggregator.zig
@@ -62,7 +62,9 @@ pub const BandwidthAggregator = struct {
         self.mutex.lock();
         defer self.mutex.unlock();
 
-        self.reports.put(report.node_id, report) catch {};
+        self.reports.put(report.node_id, report) catch |err| {
+            std.log.debug("bandwidth_aggregator: report storage failed: {}", .{err});
+        };
     }
 
     /// Generate a local bandwidth report from a RewardTracker

--- a/src/trinity_node/inference.zig
+++ b/src/trinity_node/inference.zig
@@ -352,7 +352,9 @@ pub const InferenceWorker = struct {
                 {
                     self.mutex.lock();
                     defer self.mutex.unlock();
-                    self.result_queue.append(signed_result) catch {};
+                    self.result_queue.append(signed_result) catch |err| {
+                        std.log.debug("inference: result queue append failed: {}", .{err});
+                    };
                 }
 
                 // Record job for rewards

--- a/src/trinity_node/network.zig
+++ b/src/trinity_node/network.zig
@@ -287,7 +287,9 @@ pub const NetworkNode = struct {
             defer std.posix.close(client_sock);
 
             // Handle connection
-            self.handleConnection(client_sock, std.net.Address{ .any = client_addr }) catch {};
+            self.handleConnection(client_sock, std.net.Address{ .any = client_addr }) catch |err| {
+                std.log.debug("network: handle connection failed: {}", .{err});
+            };
         }
     }
 

--- a/src/trinity_node/shard_scrubber.zig
+++ b/src/trinity_node/shard_scrubber.zig
@@ -84,7 +84,9 @@ pub const ShardScrubber = struct {
                     .detected_at = std.time.timestamp(),
                     .expected_hash = expected_hash,
                     .actual_hash = actual_hash,
-                }) catch {};
+                }) catch |err| {
+                    std.log.debug("shard_scrubber: corrupted shard record failed: {}", .{err});
+                };
                 self.corruptions_found += 1;
                 found += 1;
             }


### PR DESCRIPTION
## Summary
- Replace empty `catch {}` blocks with proper error logging in 4 production code paths
- Errors in connection handling, report storage, result queue, and shard scrubbing will now be logged for debugging

## Changes
| File | Line | Context |
|------|------|---------|
| `network.zig` | 290 | Connection handling |
| `bandwidth_aggregator.zig` | 65 | Report storage |
| `inference.zig` | 355 | Result queue append |
| `shard_scrubber.zig` | 87 | Corrupted shard record |

## Test plan
- [x] Code follows the pattern specified in the issue
- [x] Files edited match the 4 listed files
- [x] Test files and config files not modified (as specified)

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)