### PR TITLE
fix(node): replace empty catch {} in distributed.zig and remote_storage.zig

### DIFF
--- a/src/trinity_node/distributed.zig
+++ b/src/trinity_node/distributed.zig
@@ -166,7 +166,9 @@ pub const PipelineWorker = struct {
 
         // Enable SO_REUSEADDR
         const optval: u32 = 1;
-        std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&optval)) catch {};
+        std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&optval)) catch |err| {
+            std.log.debug("distributed: setsockopt SO_REUSEADDR failed: {}", .{err});
+        };
 
         std.posix.bind(sock, &addr.any, addr.getOsSockLen()) catch |err| {
             std.debug.print("\x1b[38;2;239;68;68m[Worker] Bind error on port {d}: {}\x1b[0m\n", .{ self.listen_port, err });
@@ -460,7 +462,9 @@ pub const PipelineRelay = struct {
         defer std.posix.close(sock);
 
         const optval: u32 = 1;
-        std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&optval)) catch {};
+        std.posix.setsockopt(sock, std.posix.SOL.SOCKET, std.posix.SO.REUSEADDR, std.mem.asBytes(&optval)) catch |err| {
+            std.log.debug("distributed: setsockopt SO_REUSEADDR failed: {}", .{err});
+        };
 
         std.posix.bind(sock, &addr.any, addr.getOsSockLen()) catch |err| {
             std.debug.print("\x1b[38;2;239;68;68m[Relay] Bind error on port {d}: {}\x1b[0m\n", .{ self.listen_port, err });
@@ -1112,7 +1116,9 @@ fn parseIpv4(host: []const u8) [4]u8 {
 /// Set TCP_NODELAY to disable Nagle's algorithm (reduces latency for small writes)
 fn setTcpNodelay(sock: std.posix.socket_t) void {
     const optval: u32 = 1;
-    std.posix.setsockopt(sock, std.posix.IPPROTO.TCP, std.posix.TCP.NODELAY, std.mem.asBytes(&optval)) catch {};
+    std.posix.setsockopt(sock, std.posix.IPPROTO.TCP, std.posix.TCP.NODELAY, std.mem.asBytes(&optval)) catch |err| {
+        std.log.debug("distributed: setsockopt TCP_NODELAY failed: {}", .{err});
+    };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/trinity_node/remote_storage.zig
+++ b/src/trinity_node/remote_storage.zig
@@ -246,7 +246,9 @@ pub const NetworkShardDistributor = struct {
             }
 
             // Cache locally for future access
-            _ = self.local_storage.storeShard(shard_hash, data) catch {};
+            _ = self.local_storage.storeShard(shard_hash, data) catch |err| {
+                std.log.debug("remote_storage: cache shard locally failed: {}", .{err});
+            };
 
             return data;
         }


### PR DESCRIPTION
## Summary
- Replace 4 empty `catch {}` blocks with proper `std.log.debug()` error logging
- distributed.zig: 3 setsockopt calls (2x SO_REUSEADDR, 1x TCP_NODELAY)
- remote_storage.zig: 1 storeShard cache call

## Changes
1. `src/trinity_node/distributed.zig:169` — SO_REUSEADDR in worker socket
2. `src/trinity_node/distributed.zig:463` — SO_REUSEADDR in relay socket  
3. `src/trinity_node/distributed.zig:1115` — TCP_NODELAY in setTcpNodelay helper
4. `src/trinity_node/remote_storage.zig:249` — local cache shard storage

## Test plan
- [x] `zig ast-check` passes on both files
- [x] `zig fmt` applied

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)