### PR TITLE
fix(agent_mu): replace empty catch {} with error logging in mcp_nexus.zig

### DIFF
--- a/src/agent_mu/mcp_nexus.zig
+++ b/src/agent_mu/mcp_nexus.zig
@@ -255,7 +255,9 @@ pub const McpNexus = struct {
 
         while (a_words.next()) |word| {
             a_count += 1;
-            a_list.append(self.allocator, self.allocator.dupe(u8, word) catch continue) catch {};
+            a_list.append(self.allocator, self.allocator.dupe(u8, word) catch continue) catch |err| {
+                std.log.debug("mcp_nexus: append word to argument list failed: {}", .{err});
+            };
         }
 
         var b_words = std.mem.tokenizeScalar(u8, b, ' ');


### PR DESCRIPTION
## Summary
- Replace empty `catch {}` at line 258 with proper error logging
- Adds debug log message for append failures to argument list

## Test plan
- [x] `zig fmt` passes on edited file
- [x] No empty `catch {}` remains in mcp_nexus.zig

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)