### PR TITLE
fix(tri): replace catch unreachable with try in knowledge_graph.zig timer init

### DIFF
--- a/src/knowledge_graph.zig
+++ b/src/knowledge_graph.zig
@@ -666,7 +666,7 @@ test "benchmark KnowledgeGraph" {
     const countries = [_][]const u8{ "France", "Germany", "Italy", "Spain", "UK", "Poland", "Sweden", "Norway", "Finland", "Denmark" };
     const capitals = [_][]const u8{ "Paris", "Berlin", "Rome", "Madrid", "London", "Warsaw", "Stockholm", "Oslo", "Helsinki", "Copenhagen" };
 
-    var timer = std.time.Timer.start() catch unreachable;
+    var timer = try std.time.Timer.start();
 
     // inand andin
     for (countries, capitals) |country, capital| {


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with `try` for Timer.start() in knowledge_graph.zig benchmark test
- The Timer.start() call at line 669 now properly propagates errors instead of crashing

## Changes
- `src/knowledge_graph.zig`: Changed `std.time.Timer.start() catch unreachable` to `try std.time.Timer.start()`

## Test Plan
- [x] `zig fmt src/knowledge_graph.zig` passes
- [x] `zig ast-check src/knowledge_graph.zig` passes (syntax verification)
- [x] No more `catch unreachable` on Timer.start() in knowledge_graph.zig

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)