### PR TITLE
fix(tri): replace 4 catch unreachable with try in unified_output.zig

### DIFF
--- a/src/tri/e2e_registry_tests.zig
+++ b/src/tri/e2e_registry_tests.zig
@@ -271,7 +271,7 @@ test "e2e.artifacts.collector_validates_patterns" {
 test "e2e.unified_output.success_format" {
     const allocator = std.testing.allocator;
 
-    var output = unified_output.UnifiedOutput.init(allocator, "test_cmd", .system);
+    var output = try unified_output.UnifiedOutput.init(allocator, "test_cmd", .system);
     defer output.deinit();
 
     try output.setSummary("Operation completed successfully");
@@ -296,7 +296,7 @@ test "e2e.unified_output.success_format" {
 test "e2e.unified_output.failure_format" {
     const allocator = std.testing.allocator;
 
-    var output = unified_output.UnifiedOutput.init(allocator, "test_cmd", .system);
+    var output = try unified_output.UnifiedOutput.init(allocator, "test_cmd", .system);
     defer output.deinit();
 
     try output.setSummary("Operation failed");

--- a/src/tri/math/commands.zig
+++ b/src/tri/math/commands.zig
@@ -255,7 +255,7 @@ pub fn runConstantsCommand(allocator: std.mem.Allocator, args: []const []const u
     if (global_json or std.mem.eql(u8, format_type, "json")) {
         // Use UnifiedOutput for global JSON mode
         if (global_json) {
-            var output = unified.UnifiedOutput.init(allocator, "constants", .core);
+            var output = try unified.UnifiedOutput.init(allocator, "constants", .core);
             defer output.deinit();
 
             try output.setSummary("Sacred mathematics constants");
@@ -384,7 +384,7 @@ pub fn runComputeCommand(allocator: std.mem.Allocator, args: []const []const u8)
 
 pub fn runPhiCommand(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (args.len == 0) {
-        var output = unified.UnifiedOutput.init(allocator, "phi", .core);
+        var output = try unified.UnifiedOutput.init(allocator, "phi", .core);
         defer output.deinit();
         output.setStatus(.failure);
         try output.setSummary("Usage: tri phi <n>");
@@ -396,7 +396,7 @@ pub fn runPhiCommand(allocator: std.mem.Allocator, args: []const []const u8) !vo
 
     // Parse n with inline error handling
     const n = std.fmt.parseInt(usize, args[0], 10) catch {
-        var output = unified.UnifiedOutput.init(allocator, "phi", .core);
+        var output = try unified.UnifiedOutput.init(allocator, "phi", .core);
         defer output.deinit();
         output.setStatus(.failure);
         try output.setSummary("Invalid argument: n must be a non-negative integer");
@@ -406,7 +406,7 @@ pub fn runPhiCommand(allocator: std.mem.Allocator, args: []const []const u8) !vo
         return tri_exit_codes.exitWithCode(.validation_error);
     };
 
-    var output = unified.UnifiedOutput.init(allocator, "phi", .core);
+    var output = try unified.UnifiedOutput.init(allocator, "phi", .core);
     defer output.deinit();
 
     // Compute phi^n
@@ -514,7 +514,7 @@ pub fn runCompareCommand(allocator: std.mem.Allocator, args: []const []const u8)
 pub fn runBenchCommand(allocator: std.mem.Allocator, args: []const []const u8) !void {
     _ = args;
 
-    var output = unified.UnifiedOutput.init(allocator, "bench", .dev);
+    var output = try unified.UnifiedOutput.init(allocator, "bench", .dev);
     defer output.deinit();
 
     try output.setSummary("Performance benchmarks completed successfully");

--- a/src/tri/tri_job.zig
+++ b/src/tri/tri_job.zig
@@ -41,7 +41,7 @@ fn escapeJsonString(allocator: std.mem.Allocator, str: []const u8) ![]const u8 {
 
 pub fn runJobStart(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (args.len < 1) {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-start", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-start", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary("Usage: tri job start <command> [args...]");
@@ -57,7 +57,7 @@ pub fn runJobStart(allocator: std.mem.Allocator, args: []const []const u8) !void
     defer job_manager.deinit();
 
     const job_id = job_manager.start(command, command_args, .{}) catch |err| {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-start", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-start", .agent);
         defer output.deinit();
         output.setStatus(.failure);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Failed to start job: {}", .{err}));
@@ -66,7 +66,7 @@ pub fn runJobStart(allocator: std.mem.Allocator, args: []const []const u8) !void
         return;
     };
 
-    var output = unified_output.UnifiedOutput.init(allocator, "job-start", .agent);
+    var output = try unified_output.UnifiedOutput.init(allocator, "job-start", .agent);
     defer output.deinit();
 
     try output.setSummary(try std.fmt.allocPrint(allocator, "Job {s} started", .{job_id}));
@@ -80,7 +80,7 @@ pub fn runJobStart(allocator: std.mem.Allocator, args: []const []const u8) !void
 
 pub fn runJobStatus(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (args.len < 1) {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-status", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-status", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary("Usage: tri job status <job_id>");
@@ -96,7 +96,7 @@ pub fn runJobStatus(allocator: std.mem.Allocator, args: []const []const u8) !voi
 
     const status_opt = try job_manager.status(allocator, job_id);
     if (status_opt == null) {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-status", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-status", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Job not found: {s}", .{job_id}));
@@ -108,7 +108,7 @@ pub fn runJobStatus(allocator: std.mem.Allocator, args: []const []const u8) !voi
     var status = status_opt.?;
     defer status.deinit(allocator);
 
-    var output = unified_output.UnifiedOutput.init(allocator, "job-status", .agent);
+    var output = try unified_output.UnifiedOutput.init(allocator, "job-status", .agent);
     defer output.deinit();
 
     const exec_status: unified_output.ExecutionStatus = switch (status.state) {
@@ -131,7 +131,7 @@ pub fn runJobStatus(allocator: std.mem.Allocator, args: []const []const u8) !voi
 
 pub fn runJobLogs(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (args.len < 1) {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-logs", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-logs", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary("Usage: tri job logs <job_id>");
@@ -147,7 +147,7 @@ pub fn runJobLogs(allocator: std.mem.Allocator, args: []const []const u8) !void 
 
     const logs_opt = try job_manager.getLogs(allocator, job_id);
     if (logs_opt == null) {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-logs", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-logs", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Job not found: {s}", .{job_id}));
@@ -158,7 +158,7 @@ pub fn runJobLogs(allocator: std.mem.Allocator, args: []const []const u8) !void 
 
     const logs = logs_opt.?;
 
-    var output = unified_output.UnifiedOutput.init(allocator, "job-logs", .agent);
+    var output = try unified_output.UnifiedOutput.init(allocator, "job-logs", .agent);
     defer output.deinit();
 
     try output.setSummary(try std.fmt.allocPrint(allocator, "Logs for job {s}", .{job_id}));
@@ -190,7 +190,7 @@ pub fn runJobLogs(allocator: std.mem.Allocator, args: []const []const u8) !void 
 
 pub fn runJobArtifacts(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (args.len < 1) {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary("Usage: tri job artifacts <job_id>");
@@ -205,7 +205,7 @@ pub fn runJobArtifacts(allocator: std.mem.Allocator, args: []const []const u8) !
     defer job_manager.deinit();
 
     _ = job_manager.getArtifacts(allocator, job_id) catch |err| {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
         defer output.deinit();
         output.setStatus(.failure);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Failed to get artifacts: {}", .{err}));
@@ -215,7 +215,7 @@ pub fn runJobArtifacts(allocator: std.mem.Allocator, args: []const []const u8) !
     };
 
     var collector = job_artifact.ArtifactCollector.init(allocator, job_id) catch |err| {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
         defer output.deinit();
         output.setStatus(.failure);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Failed to open artifacts: {}", .{err}));
@@ -226,7 +226,7 @@ pub fn runJobArtifacts(allocator: std.mem.Allocator, args: []const []const u8) !
     defer collector.deinit();
 
     const manifest = collector.collect(&.{}) catch |err| {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
         defer output.deinit();
         output.setStatus(.failure);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Failed to collect artifacts: {}", .{err}));
@@ -244,7 +244,7 @@ pub fn runJobArtifacts(allocator: std.mem.Allocator, args: []const []const u8) !
         allocator.free(manifest.artifacts);
     }
 
-    var output = unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
+    var output = try unified_output.UnifiedOutput.init(allocator, "job-artifacts", .agent);
     defer output.deinit();
 
     try output.setSummary(try std.fmt.allocPrint(allocator, "Artifacts for job {s}: {d} files", .{ job_id, manifest.artifacts.len }));
@@ -270,7 +270,7 @@ pub fn runJobArtifacts(allocator: std.mem.Allocator, args: []const []const u8) !
 
 pub fn runJobCancel(allocator: std.mem.Allocator, args: []const []const u8) !void {
     if (args.len < 1) {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-cancel", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-cancel", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary("Usage: tri job cancel <job_id>");
@@ -285,7 +285,7 @@ pub fn runJobCancel(allocator: std.mem.Allocator, args: []const []const u8) !voi
     defer job_manager.deinit();
 
     const cancelled = job_manager.cancel(job_id) catch |err| {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-cancel", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-cancel", .agent);
         defer output.deinit();
         output.setStatus(.failure);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Failed to cancel job: {}", .{err}));
@@ -295,7 +295,7 @@ pub fn runJobCancel(allocator: std.mem.Allocator, args: []const []const u8) !voi
     };
 
     if (!cancelled) {
-        var output = unified_output.UnifiedOutput.init(allocator, "job-cancel", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "job-cancel", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Job not running: {s}", .{job_id}));
@@ -304,7 +304,7 @@ pub fn runJobCancel(allocator: std.mem.Allocator, args: []const []const u8) !voi
         return;
     }
 
-    var output = unified_output.UnifiedOutput.init(allocator, "job-cancel", .agent);
+    var output = try unified_output.UnifiedOutput.init(allocator, "job-cancel", .agent);
     defer output.deinit();
 
     // Exit code is set by setStatus(.canceled)
@@ -329,7 +329,7 @@ pub fn runJobList(allocator: std.mem.Allocator, args: []const []const u8) !void 
         allocator.free(job_ids);
     }
 
-    var output = unified_output.UnifiedOutput.init(allocator, "job-list", .agent);
+    var output = try unified_output.UnifiedOutput.init(allocator, "job-list", .agent);
     defer output.deinit();
 
     try output.setSummary(try std.fmt.allocPrint(allocator, "{d} jobs", .{job_ids.len}));

--- a/src/tri/tri_mcp.zig
+++ b/src/tri/tri_mcp.zig
@@ -24,7 +24,7 @@ pub fn runMcpCommand(allocator: std.mem.Allocator, args: []const []const u8) !vo
     } else if (std.mem.eql(u8, subcommand, "help")) {
         return showMcpHelp(allocator);
     } else {
-        var output = unified_output.UnifiedOutput.init(allocator, "mcp", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "mcp", .agent);
         defer output.deinit();
         output.setStatus(.denied);
         try output.setSummary("Unknown MCP subcommand");
@@ -48,7 +48,7 @@ fn runExportCommand(allocator: std.mem.Allocator, args: []const []const u8) !voi
         // Export to file
         try registry.exportMcpSchemas(allocator, output_path);
 
-        var output = unified_output.UnifiedOutput.init(allocator, "mcp-export", .agent);
+        var output = try unified_output.UnifiedOutput.init(allocator, "mcp-export", .agent);
         defer output.deinit();
         output.setStatus(.success);
         try output.setSummary(try std.fmt.allocPrint(allocator, "Exported MCP schemas to {s}", .{output_path}));
@@ -59,7 +59,7 @@ fn runExportCommand(allocator: std.mem.Allocator, args: []const []const u8) !voi
 fn runDoctorCommand(allocator: std.mem.Allocator, args: []const []const u8) !void {
     _ = args;
 
-    var output = unified_output.UnifiedOutput.init(allocator, "mcp-doctor", .agent);
+    var output = try unified_output.UnifiedOutput.init(allocator, "mcp-doctor", .agent);
     defer output.deinit();
 
     var issues = try std.ArrayList([]const u8).initCapacity(allocator, 8);
@@ -189,7 +189,7 @@ fn runDoctorCommand(allocator: std.mem.Allocator, args: []const []const u8) !voi
 fn runToolsCommand(allocator: std.mem.Allocator, args: []const []const u8) !void {
     _ = args;
 
-    var output = unified_output.UnifiedOutput.init(allocator, "mcp-tools", .agent);
+    var output = try unified_output.UnifiedOutput.init(allocator, "mcp-tools", .agent);
     defer output.deinit();
 
     try output.setSummary("MCP-enabled tools");

--- a/src/tri/tri_register.zig
+++ b/src/tri/tri_register.zig
@@ -1324,7 +1324,7 @@ pub fn runFpgaCommand(allocator: std.mem.Allocator, args: []const []const u8) !v
 
     if (args.len < 1) {
         // Show help with UnifiedOutput in JSON mode
-        var output = unified_mod.UnifiedOutput.init(allocator, "fpga", .forge);
+        var output = try unified_mod.UnifiedOutput.init(allocator, "fpga", .forge);
         defer output.deinit();
 
         try output.setSummary("FPGA command requires a subcommand");
@@ -1395,7 +1395,7 @@ pub fn runFpgaCommand(allocator: std.mem.Allocator, args: []const []const u8) !v
         return tri_fpga.runFpgaStatusCommand(allocator, sub_args);
     } else {
         // Unknown subcommand - use UnifiedOutput for error
-        var output = unified_mod.UnifiedOutput.init(allocator, "fpga", .forge);
+        var output = try unified_mod.UnifiedOutput.init(allocator, "fpga", .forge);
         defer output.deinit();
 
         output.setStatus(.failure);
@@ -1431,7 +1431,7 @@ pub fn runCommand(allocator: std.mem.Allocator, name: []const u8, args: []const 
     }
     // Command not found
     const unified_mod = @import("../tri/unified_output.zig");
-    var output = unified_mod.UnifiedOutput.init(allocator, name, .agent);
+    var output = try unified_mod.UnifiedOutput.init(allocator, name, .agent);
     defer output.deinit();
     output.setStatus(.denied);
     try output.setSummary("Unknown command");

--- a/src/tri/unified_output.zig
+++ b/src/tri/unified_output.zig
@@ -263,7 +263,7 @@ pub const UnifiedOutput = struct {
     registry_metadata: ?RegistryMetadata,
 
     /// Initialize a new UnifiedOutput
-    pub fn init(allocator: std.mem.Allocator, command_name: []const u8, namespace: Namespace) UnifiedOutput {
+    pub fn init(allocator: std.mem.Allocator, command_name: []const u8, namespace: Namespace) std.mem.Allocator.Error!UnifiedOutput {
         return UnifiedOutput{
             .allocator = allocator,
             .status = .success,
@@ -273,10 +273,10 @@ pub const UnifiedOutput = struct {
             .start_time = std.time.timestamp(),
             .end_time = 0,
             .metrics = std.StringHashMap(u64).init(allocator),
-            .artifacts = std.ArrayList(ArtifactInfo).initCapacity(allocator, 4) catch unreachable,
-            .warnings = std.ArrayList(Warning).initCapacity(allocator, 4) catch unreachable,
-            .errors = std.ArrayList(Error).initCapacity(allocator, 4) catch unreachable,
-            .next_actions = std.ArrayList([]const u8).initCapacity(allocator, 4) catch unreachable,
+            .artifacts = try std.ArrayList(ArtifactInfo).initCapacity(allocator, 4),
+            .warnings = try std.ArrayList(Warning).initCapacity(allocator, 4),
+            .errors = try std.ArrayList(Error).initCapacity(allocator, 4),
+            .next_actions = try std.ArrayList([]const u8).initCapacity(allocator, 4),
             .data = null,
             .data_raw = null,
             .verdict = null,
@@ -695,7 +695,7 @@ fn jsonEscapeString(writer: anytype, str: []const u8) !void {
 
 /// Create a successful output
 pub fn success(allocator: std.mem.Allocator, command_name: []const u8, namespace: Namespace, summary: []const u8) !UnifiedOutput {
-    var output = UnifiedOutput.init(allocator, command_name, namespace);
+    var output = try UnifiedOutput.init(allocator, command_name, namespace);
     try output.setSummary(summary);
     output.finalize();
     return output;
@@ -703,7 +703,7 @@ pub fn success(allocator: std.mem.Allocator, command_name: []const u8, namespace
 
 /// Create a failed output
 pub fn failure(allocator: std.mem.Allocator, command_name: []const u8, namespace: Namespace, summary: []const u8, error_code: []const u8, error_msg: []const u8) !UnifiedOutput {
-    var output = UnifiedOutput.init(allocator, command_name, namespace);
+    var output = try UnifiedOutput.init(allocator, command_name, namespace);
     try output.setSummary(summary);
     try output.addError(error_code, error_msg);
     output.finalize();
@@ -712,7 +712,7 @@ pub fn failure(allocator: std.mem.Allocator, command_name: []const u8, namespace
 
 /// Create a partial success output
 pub fn partial(allocator: std.mem.Allocator, command_name: []const u8, namespace: Namespace, summary: []const u8) !UnifiedOutput {
-    var output = UnifiedOutput.init(allocator, command_name, namespace);
+    var output = try UnifiedOutput.init(allocator, command_name, namespace);
     try output.setSummary(summary);
     output.setStatus(.partial);
     output.finalize();
@@ -734,7 +734,7 @@ test "ExecutionStatus.toString" {
 
 test "UnifiedOutput basic JSON output" {
     const allocator = std.testing.allocator;
-    var output = UnifiedOutput.init(allocator, "test_cmd", .core);
+    var output = try UnifiedOutput.init(allocator, "test_cmd", .core);
     try output.setSummary("Test completed successfully");
     try output.addMetric("items_processed", 42);
     output.finalize();
@@ -756,7 +756,7 @@ test "UnifiedOutput basic JSON output" {
 
 test "UnifiedOutput with errors" {
     const allocator = std.testing.allocator;
-    var output = UnifiedOutput.init(allocator, "validate", .system);
+    var output = try UnifiedOutput.init(allocator, "validate", .system);
     try output.setSummary("Validation failed");
     try output.addError("VALIDATION_ERROR", "Invalid input format");
     output.finalize();
@@ -776,7 +776,7 @@ test "UnifiedOutput with errors" {
 
 test "UnifiedOutput with warnings" {
     const allocator = std.testing.allocator;
-    var output = UnifiedOutput.init(allocator, "build", .dev);
+    var output = try UnifiedOutput.init(allocator, "build", .dev);
     try output.setSummary("Build completed with warnings");
     try output.addWarning("DEPRECATION", "Using deprecated feature");
     try output.addMetric("warnings_count", 1);
@@ -797,7 +797,7 @@ test "UnifiedOutput.getExitCode" {
 
     // Success case
     {
-        var output = UnifiedOutput.init(allocator, "success_cmd", .core);
+        var output = try UnifiedOutput.init(allocator, "success_cmd", .core);
         try output.setSummary("Success");
         output.finalize();
         try std.testing.expectEqual(exit_codes.ExitCode.success, output.getExitCode());
@@ -806,7 +806,7 @@ test "UnifiedOutput.getExitCode" {
 
     // Error case - validation error
     {
-        var output = UnifiedOutput.init(allocator, "error_cmd", .system);
+        var output = try UnifiedOutput.init(allocator, "error_cmd", .system);
         try output.setSummary("Error");
         try output.addError("VALIDATION_ERROR", "Invalid input");
         output.finalize();
@@ -816,7 +816,7 @@ test "UnifiedOutput.getExitCode" {
 
     // Error case - timeout
     {
-        var output = UnifiedOutput.init(allocator, "timeout_cmd", .agent);
+        var output = try UnifiedOutput.init(allocator, "timeout_cmd", .agent);
         try output.setSummary("Timeout");
         try output.addError("TIMEOUT", "Operation timed out");
         output.finalize();
@@ -826,7 +826,7 @@ test "UnifiedOutput.getExitCode" {
 
     // Partial case (still success)
     {
-        var output = UnifiedOutput.init(allocator, "partial_cmd", .dev);
+        var output = try UnifiedOutput.init(allocator, "partial_cmd", .dev);
         try output.setSummary("Partial");
         output.setStatus(.partial);
         output.finalize();


### PR DESCRIPTION
## Summary
- Fixes `src/tri/unified_output.zig` lines 276-279 where `catch unreachable` was used on `initCapacity` calls that can fail with OutOfMemory
- Changed `UnifiedOutput.init()` to return `std.mem.Allocator.Error!UnifiedOutput` instead of `UnifiedOutput`
- Replaced all 4 `catch unreachable` with `try` for proper error propagation
- Updated all 29 callers across 5 additional files to use `try` when calling `UnifiedOutput.init()`

## Files Modified
- `src/tri/unified_output.zig` - Main fix: init function now returns error union
- `src/tri/tri_register.zig` - 4 callers updated
- `src/tri/tri_mcp.zig` - 4 callers updated
- `src/tri/math/commands.zig` - 5 callers updated
- `src/tri/tri_job.zig` - 14 callers updated
- `src/tri/e2e_registry_tests.zig` - 2 callers updated

## Test Plan
- [x] `zig fmt src/` - All modified files formatted
- [x] `zig ast-check` - All modified files pass syntax check
- [x] `zig test src/tri/unified_output.zig` - All 5 tests pass
- [x] No `catch unreachable` remains in unified_output.zig init function

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)