### PR TITLE
fix(mcp): memory leak in getDirectExecutableCommands — string duplicates never freed

### DIFF
--- a/tools/mcp/trinity_mcp/direct_executor.zig
+++ b/tools/mcp/trinity_mcp/direct_executor.zig
@@ -53,10 +53,7 @@ pub fn executeCommandOptimized(
 }
 
 /// Get list of commands that support direct execution
-pub fn getDirectExecutableCommands(allocator: std.mem.Allocator) ![][]const u8 {
-    const list = try allocator.alloc([]const u8, DIRECT_EXEC_WHITELIST.len);
-    for (DIRECT_EXEC_WHITELIST, 0..) |cmd, i| {
-        list[i] = try allocator.dupe(u8, cmd);
-    }
-    return list;
+/// Returns pointer to comptime constant - no allocation needed
+pub fn getDirectExecutableCommands() []const []const u8 {
+    return &DIRECT_EXEC_WHITELIST;
 }


### PR DESCRIPTION
## Summary
- Fixed memory leak in `getDirectExecutableCommands()` by eliminating unnecessary allocations
- Since `DIRECT_EXEC_WHITELIST` is a comptime constant, we now return a pointer to it directly
- Changed function signature from `getDirectExecutableCommands(allocator) ![][]const u8` to `getDirectExecutableCommands() []const []const u8`

## Changes
- Removed allocator parameter (no longer needed)
- Changed return type to `[]const []const u8` (const slice of const strings)
- Return `&DIRECT_EXEC_WHITELIST` directly with zero allocations

## Test plan
- [x] `zig fmt` passes
- [x] File compiles correctly (verified with zig build)

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)