### PR TITLE
fix(mcp): memory leak — WebSocket frame payload not freed in handleConnection loop

### DIFF
--- a/tools/mcp/trinity_mcp/websocket_transport.zig
+++ b/tools/mcp/trinity_mcp/websocket_transport.zig
@@ -31,6 +31,8 @@ pub const Frame = struct {
     fin: bool,
     opcode: Opcode,
     payload: []const u8,
+    /// True if payload was allocated and must be freed by caller
+    allocated: bool,
 };
 
 /// WebSocket Server for MCP protocol
@@ -131,6 +133,8 @@ pub const WebSocketServer = struct {
                 std.log.err("Frame parse error: {}", .{err});
                 continue;
             };
+            // Free allocated payload after processing (prevents memory leak on masked frames)
+            defer if (frame.allocated) self.allocator.free(frame.payload);
 
             // Handle different opcodes
             switch (frame.opcode) {
@@ -246,18 +250,21 @@ pub const WebSocketServer = struct {
 
         // Unmask payload if needed
         var payload: []const u8 = payload_data;
+        var allocated = false;
         if (masked) {
             const unmasked = try self.allocator.alloc(u8, payload_len);
             for (0..payload_len) |i| {
                 unmasked[i] = payload_data[i] ^ masking_key[i % 4];
             }
             payload = unmasked;
+            allocated = true;
         }
 
         return Frame{
             .fin = fin,
             .opcode = opcode,
             .payload = payload,
+            .allocated = allocated,
         };
     }
 


### PR DESCRIPTION
## Summary
- Added `allocated: bool` field to `Frame` struct to track when payload memory was allocated during unmasking of masked WebSocket frames
- Added `defer` statement in `handleConnection()` loop to free the payload when it was allocated, preventing memory leak

## Problem
`tools/mcp/trinity_mcp/websocket_transport.zig` had a memory leak in the `handleConnection()` loop. When `parseFrame()` processed a masked WebSocket frame, it allocated memory for the unmasked payload. But after processing the frame in the switch statement, the payload was never freed.

## Fix
The fix adds an `allocated` boolean to the `Frame` struct that is set to `true` when memory is allocated for unmasking, and then a `defer` statement in `handleConnection()` frees the payload when needed:

```zig
defer if (frame.allocated) self.allocator.free(frame.payload);
```

## Test Plan
- [x] `zig build` compiles successfully
- [x] `zig ast-check` passes
- [x] Frame payload is freed after each iteration of the handleConnection loop
- [x] No memory leak on masked WebSocket frames

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)