### PR TITLE
fix(tri): replace empty catch {} on child.wait() in job_system.zig (#210)

### DIFF
--- a/src/tri/job_system.zig
+++ b/src/tri/job_system.zig
@@ -573,7 +573,9 @@ pub const Job = struct {
     fn deinit(self: *Job) void {
         if (self.child_process) |*child| {
             _ = child.kill() catch {};
-            _ = child.wait() catch {};
+            _ = child.wait() catch |err| {
+                std.log.debug("job_system: child.wait failed: {}", .{err});
+            };
         }
 
         self.allocator.free(self.dir_path);


### PR DESCRIPTION
## Summary
- Replace empty `catch {}` on `child.wait()` with proper debug logging in `Job.deinit()`
- Other `child.wait()` calls in job_system.zig already have proper error handling — only line 576 needed fixing

## Changes
```zig
// Before
_ = child.wait() catch {};

// After  
_ = child.wait() catch |err| {
    std.log.debug("job_system: child.wait failed: {}", .{err});
};
```

## Acceptance Criteria Met
- [x] `zig fmt` passes
- [x] Line 576 no longer has empty `catch {}`
- [x] No `child.deinit()` call (method doesn't exist in Zig 0.15.2)

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)