### PR TITLE
fix(cloud): add error logging to child.wait() catch blocks

### DIFF
--- a/src/tri/job_system.zig
+++ b/src/tri/job_system.zig
@@ -573,7 +573,9 @@ pub const Job = struct {
     fn deinit(self: *Job) void {
         if (self.child_process) |*child| {
             _ = child.kill() catch {};
-            _ = child.wait() catch {};
+            _ = child.wait() catch |err| {
+                std.log.debug("job_system: child.wait failed: {}", .{err});
+            };
         }
 
         self.allocator.free(self.dir_path);

--- a/tools/mcp/trinity_mcp/cloud_monitor.zig
+++ b/tools/mcp/trinity_mcp/cloud_monitor.zig
@@ -373,7 +373,9 @@ fn sendTriNotify(issue: u32, status_str: []const u8, detail: []const u8) void {
     child.stdout_behavior = .Ignore;
     child.stderr_behavior = .Ignore;
     child.spawn() catch return;
-    _ = child.wait() catch {};
+    _ = child.wait() catch |err| {
+        std.log.debug("cloud_monitor: child.wait failed: {}", .{err});
+    };
 }
 
 fn setStatus(entry: *AgentStatus, status_str: []const u8, detail: []const u8) void {

--- a/tools/mcp/trinity_mcp/cloud_tools.zig
+++ b/tools/mcp/trinity_mcp/cloud_tools.zig
@@ -71,7 +71,9 @@ fn runTriCloud(buf: *[MAX_OUTPUT]u8, args: []const []const u8) []const u8 {
         return copyToBuf(buf, "Error: Failed to read output");
     };
 
-    _ = child.wait() catch {};
+    _ = child.wait() catch |err| {
+        std.log.debug("cloud_tools: child.wait failed: {}", .{err});
+    };
 
     if (stdout.len == 0) {
         return copyToBuf(buf, "OK (no output)");


### PR DESCRIPTION
## Summary
- Replace 3 empty `catch {}` on `child.wait()` calls with proper error logging
- Files modified: `cloud_tools.zig`, `cloud_monitor.zig`, `job_system.zig`

## Note
Issue #209 referenced `src/tri/tri_cloud.zig` lines 1294, 1356, 1438, but:
- That file has only 1166 lines
- It contains no `child.wait()` calls

Fixed the actual instances found in cloud-related files.

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)