### PR TITLE
fix(tri): replace 3 empty catch {} with error logging

### DIFF
--- a/src/tri/chat_server.zig
+++ b/src/tri/chat_server.zig
@@ -750,7 +750,9 @@ pub const ChatServer = struct {
 
         try json.appendSlice(self.allocator, "{\"agent\":");
         var agent_buf: [4]u8 = undefined;
-        _ = std.fmt.bufPrint(&agent_buf, "{d}", .{agent_idx}) catch {};
+        _ = std.fmt.bufPrint(&agent_buf, "{d}", .{agent_idx}) catch |err| {
+            std.log.debug("chat_server: format agent_idx failed: {}", .{err});
+        };
         const agent_str_len = std.mem.indexOfScalar(u8, &agent_buf, 0) orelse 1;
         try json.appendSlice(self.allocator, agent_buf[0..agent_str_len]);
 

--- a/src/tri/main.zig
+++ b/src/tri/main.zig
@@ -936,7 +936,9 @@ fn logAgentCommand(cmd_args: []const []const u8) void {
     };
     defer file.close();
     file.seekFromEnd(0) catch return;
-    file.writeAll(line) catch {};
+    file.writeAll(line) catch |err| {
+        std.log.debug("main: write history line failed: {}", .{err});
+    };
 
     // Fire-and-forget Telegram notification
     sendAgentTelegram(line);
@@ -1020,7 +1022,9 @@ fn sendAgentTelegram(line: []const u8) void {
         .extra_headers = &.{
             .{ .name = "Content-Type", .value = "application/json" },
         },
-    }) catch {};
+    }) catch |err| {
+        std.log.debug("main: telegram notification failed: {}", .{err});
+    };
 }
 
 /// Keep last AGENT_CMD_KEEP_LINES lines when log exceeds max.


### PR DESCRIPTION
## Summary
- Replace 3 empty `catch {}` statements with proper error logging
- `main.zig:939` — log write history line failures
- `main.zig:1023` — log telegram notification failures  
- `chat_server.zig:753` — log agent_idx format failures

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)