### PR TITLE
fix(cloud): replace 5 remaining catch {} with error logging in tri_cloud.zig

### DIFF
--- a/src/tri/tri_cloud.zig
+++ b/src/tri/tri_cloud.zig
@@ -652,14 +652,20 @@ fn cloudHistory(_: Allocator, args: []const []const u8) !void {
                 if (std.mem.indexOf(u8, line, needle) == null) continue;
             }
 
-            if (!first) w.writeAll(",") catch {};
+            if (!first) w.writeAll(",") catch |err| {
+                std.log.debug("tri_cloud: JSON write comma failed: {}", .{err});
+            };
             first = false;
             w.writeAll(line) catch break;
             count += 1;
         }
 
-        w.writeAll("],\"count\":") catch {};
-        std.fmt.format(w, "{d}}}", .{count}) catch {};
+        w.writeAll("],\"count\":") catch |err| {
+            std.log.debug("tri_cloud: JSON write count key failed: {}", .{err});
+        };
+        std.fmt.format(w, "{d}}}", .{count}) catch |err| {
+            std.log.debug("tri_cloud: JSON format count failed: {}", .{err});
+        };
 
         print("{s}\n", .{fbs.getWritten()});
         return;
@@ -866,7 +872,9 @@ fn cloudPipeline(allocator: Allocator, args: []const []const u8) !void {
             }
 
             print("  {s}Killing and respawning...{s}\n", .{ YELLOW, RESET });
-            cloud_orchestrator.killAgent(allocator, issue_num) catch {};
+            cloud_orchestrator.killAgent(allocator, issue_num) catch |err| {
+                std.log.warn("tri_cloud: killAgent failed for issue {d}: {}", .{ issue_num, err });
+            };
             _ = cloud_orchestrator.spawnAgent(allocator, issue_num) catch |err| {
                 print("  {s}✗ Respawn failed: {}{s}\n", .{ RED, err, RESET });
                 break;
@@ -910,7 +918,9 @@ fn cloudPipeline(allocator: Allocator, args: []const []const u8) !void {
 
     // Step 6: Cleanup
     print("\n{s}[6/6] Cleaning up agent...{s}\n", .{ CYAN, RESET });
-    cloud_orchestrator.killAgent(allocator, issue_num) catch {};
+    cloud_orchestrator.killAgent(allocator, issue_num) catch |err| {
+        std.log.warn("tri_cloud: killAgent cleanup failed for issue {d}: {}", .{ issue_num, err });
+    };
     print("{s}✓ Agent destroyed{s}\n", .{ GREEN, RESET });
 
     print("\n{s}{s}═══════════════════════════════════════════════════{s}\n", .{ GOLDEN, BOLD, RESET });
@@ -1025,7 +1035,9 @@ fn cloudVerifyPR(allocator: Allocator, issue_num: u32) !bool {
         .allocator = allocator,
         .argv = &.{ "git", "checkout", "main" },
         .max_output_bytes = 4096,
-    }) catch {};
+    }) catch |err| {
+        std.log.warn("tri_cloud: git checkout main failed: {}", .{err});
+    };
 
     return true;
 }


### PR DESCRIPTION
## Summary
Replaced empty `catch {}` blocks in `src/tri/tri_cloud.zig` with proper error logging.

## Changes
- **Line ~655**: JSON write comma → `std.log.debug`
- **Line ~661-662**: JSON count key/format → `std.log.debug`
- **Line ~869**: killAgent (respawn) → `std.log.warn` with issue number
- **Line ~913**: killAgent (cleanup) → `std.log.warn` with issue number
- **Line ~1028**: git checkout main → `std.log.warn`

## Fix Pattern Applied
```zig
// Before
cloud_orchestrator.killAgent(allocator, issue_num) catch {};

// After
cloud_orchestrator.killAgent(allocator, issue_num) catch |err| {
    std.log.warn("tri_cloud: killAgent failed for issue {d}: {}", .{ issue_num, err });
};
```

## Acceptance
- [x] `zig build` compiles (tri_cloud.zig has no errors)
- [x] No empty `catch {}` in tri_cloud.zig

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)