### PR TITLE
fix(tri): replace empty catch {} with error logging in tri_context.zig and faculty_board.zig

### DIFF
--- a/src/tri/faculty_board.zig
+++ b/src/tri/faculty_board.zig
@@ -255,24 +255,34 @@ fn sendFacultyTelegram(snapshot: FacultySnapshot, delta: FacultyDelta) void {
         snapshot.binaries,
         snapshot.compile_rate,
         snapshot.v_number,
-    }) catch {};
+    }) catch |err| {
+        std.log.debug("faculty_board: write build stats failed: {}", .{err});
+    };
 
     // Agent commands (last 5 from log)
     var cmd_lines: [5][]const u8 = undefined;
     var cmd_log_buf: [1024]u8 = undefined;
     const cmd_count = lastNCommands(5, &cmd_lines, &cmd_log_buf);
     if (cmd_count > 0) {
-        w.print("\n\xf0\x9f\x93\xa1 \xd0\x9a\xd0\x9e\xd0\x9c\xd0\x90\xd0\x9d\xd0\x94\xd0\xab ({d}):\n", .{cmd_count}) catch {};
+        w.print("\n\xf0\x9f\x93\xa1 \xd0\x9a\xd0\x9e\xd0\x9c\xd0\x90\xd0\x9d\xd0\x94\xd0\xab ({d}):\n", .{cmd_count}) catch |err| {
+            std.log.debug("faculty_board: write commands header failed: {}", .{err});
+        };
         for (cmd_lines[0..cmd_count]) |line| {
-            w.print("  {s}\n", .{line}) catch {};
+            w.print("  {s}\n", .{line}) catch |err| {
+                std.log.debug("faculty_board: write command line failed: {}", .{err});
+            };
         }
     }
 
     // Analysis summary
-    w.print("\n", .{}) catch {};
+    w.print("\n", .{}) catch |err| {
+        std.log.debug("faculty_board: write newline failed: {}", .{err});
+    };
     var analysis_buf: [512]u8 = undefined;
     const analysis = analysis_engine.generateAnalysis(snapshot, delta, &analysis_buf);
-    w.print("{s}\n", .{analysis}) catch {};
+    w.print("{s}\n", .{analysis}) catch |err| {
+        std.log.debug("faculty_board: write analysis failed: {}", .{err});
+    };
 
     const msg = msg_stream.getWritten();
 
@@ -379,7 +389,9 @@ fn saveTgHash(hash: u64) void {
     const content = std.fmt.bufPrint(&buf, "{d}", .{hash}) catch return;
     const file = std.fs.cwd().createFile(TG_HASH_PATH, .{}) catch return;
     defer file.close();
-    file.writeAll(content) catch {};
+    file.writeAll(content) catch |err| {
+        std.log.debug("faculty_board: write TG hash failed: {}", .{err});
+    };
 }
 
 /// Read last N lines from agent_commands.log.
@@ -475,7 +487,9 @@ fn savePrevSnapshot(snapshot: FacultySnapshot) void {
 
     const file = std.fs.cwd().createFile(PREV_PATH, .{}) catch return;
     defer file.close();
-    file.writeAll(content) catch {};
+    file.writeAll(content) catch |err| {
+        std.log.debug("faculty_board: write prev snapshot failed: {}", .{err});
+    };
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/src/tri/tri_context.zig
+++ b/src/tri/tri_context.zig
@@ -265,7 +265,9 @@ pub const ContextManager = struct {
         for (content, 0..) |c, i| {
             if (c == '\n' or i == content.len - 1) {
                 const line = content[line_start..i];
-                self.extractSymbolFromLine(line, full_path, line_num) catch {};
+                self.extractSymbolFromLine(line, full_path, line_num) catch |err| {
+                    std.log.debug("tri_context: extractSymbolFromLine failed: {}", .{err});
+                };
                 line_start = i + 1;
                 line_num += 1;
             }
@@ -447,9 +449,13 @@ pub const ContextManager = struct {
             const sym = self.symbols.items[hit.symbol_idx];
             const analysis = self.analyzeSacredSymbol(sym.name);
             if (analysis) |sacred| {
-                std.fmt.format(writer, "//   {s}: gematria={d}\n", .{ sym.name, sacred.gematria_value }) catch {};
+                std.fmt.format(writer, "//   {s}: gematria={d}\n", .{ sym.name, sacred.gematria_value }) catch |err| {
+                    std.log.debug("tri_context: write gematria failed: {}", .{err});
+                };
                 if (sacred.recognized_constant) |rc| {
-                    std.fmt.format(writer, "//   {s}: recognized as {s}\n", .{ sym.name, rc }) catch {};
+                    std.fmt.format(writer, "//   {s}: recognized as {s}\n", .{ sym.name, rc }) catch |err| {
+                        std.log.debug("tri_context: write recognized constant failed: {}", .{err});
+                    };
                 }
             }
             std.fmt.format(writer, "//   {s}\n", .{sym.snippet}) catch break;
@@ -486,11 +492,15 @@ pub const ContextManager = struct {
         const metrics = self.sacred_metrics;
         std.fmt.format(writer, "// === EVOLUTION PROGRESS: {d:.1}% ===\n", .{
             metrics.evolution_progress * 100.0,
-        }) catch {};
+        }) catch |err| {
+            std.log.debug("tri_context: write evolution progress failed: {}", .{err});
+        };
         std.fmt.format(writer, "// Patch Candidates: {d} / {d} symbols\n", .{
             metrics.patch_candidates_found,
             metrics.total_symbols_analyzed,
-        }) catch {};
+        }) catch |err| {
+            std.log.debug("tri_context: write patch candidates failed: {}", .{err});
+        };
 
         writer.writeAll("// === END CONTEXT ===\n\n") catch return null;
 
@@ -635,7 +645,9 @@ pub const ContextManager = struct {
 
     pub fn saveIndex(self: *Self) !void {
         // Ensure directory exists
-        std.fs.cwd().makePath(".trinity-nexus") catch {};
+        std.fs.cwd().makePath(".trinity-nexus") catch |err| {
+            std.log.debug("tri_context: create .trinity-nexus directory failed: {}", .{err});
+        };
 
         const file = try std.fs.cwd().createFile(INDEX_PATH, .{});
         defer file.close();


### PR DESCRIPTION
## Summary
- Fixed 6 empty `catch {}` blocks in `src/tri/tri_context.zig` with `std.log.debug` error logging
- Fixed 7 empty `catch {}` blocks in `src/tri/faculty_board.zig` with `std.log.debug` error logging

## Fix pattern
```zig
// Before
something() catch {};

// After
something() catch |err| {
    std.log.debug("<module>: <context> failed: {}", .{err});
};
```

## Test plan
- [x] `zig ast-check` passes for both files
- [x] No empty `catch {}` remaining in either file
- [x] Syntax is correct for Zig 0.15.2

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)