### PR TITLE
fix(mcp): replace 7 empty catch {} with error logging in logger.zig

### DIFF
--- a/tools/mcp/trinity_mcp/logger.zig
+++ b/tools/mcp/trinity_mcp/logger.zig
@@ -58,9 +58,13 @@ pub const Logger = struct {
             timestamp, color, @tagName(level), reset,
         } ++ args) catch return;
 
-        self.file.writeAll(msg) catch {};
+        self.file.writeAll(msg) catch |err| {
+            std.log.debug("logger: file.writeAll failed: {}", .{err});
+        };
         // Also to stderr for immediate visibility
-        _ = posix.write(2, msg) catch {};
+        _ = posix.write(2, msg) catch |err| {
+            std.log.debug("logger: posix.write stderr failed: {}", .{err});
+        };
     }
 
     pub fn hexDump(self: *Logger, data: []const u8, max_len: usize) void {
@@ -71,20 +75,30 @@ pub const Logger = struct {
         var fbs = std.io.fixedBufferStream(&buffer);
         const writer = fbs.writer();
 
-        writer.writeAll("HEX: ") catch {};
+        writer.writeAll("HEX: ") catch |err| {
+            std.log.debug("logger: writeAll HEX prefix failed: {}", .{err});
+        };
         var i: usize = 0;
         while (i < show_len) : (i += 1) {
-            writer.print("{x:0>2} ", .{data[i]}) catch {};
+            writer.print("{x:0>2} ", .{data[i]}) catch |err| {
+                std.log.debug("logger: hex byte print failed: {}", .{err});
+            };
             if (i % 16 == 15 and i < show_len - 1) {
-                writer.writeAll("\n     ") catch {};
+                writer.writeAll("\n     ") catch |err| {
+                    std.log.debug("logger: writeAll newline indent failed: {}", .{err});
+                };
             }
         }
         if (data.len > max_len) {
-            writer.writeAll("...") catch {};
+            writer.writeAll("...") catch |err| {
+                std.log.debug("logger: writeAll truncation marker failed: {}", .{err});
+            };
         }
 
         const msg = fbs.getWritten();
-        self.file.writeAll(msg) catch {};
+        self.file.writeAll(msg) catch |err| {
+            std.log.debug("logger: hexDump file.writeAll failed: {}", .{err});
+        };
         _ = posix.write(2, msg) catch return;
     }
 };


### PR DESCRIPTION
## Summary

- Replace all 7 empty `catch {}` blocks in `tools/mcp/trinity_mcp/logger.zig` with proper error logging using `std.log.debug`
- Using `std.log.debug` avoids infinite recursion (logger logging its own failures)

## Changes

| Line | Before | After |
|------|--------|-------|
| 61 | `self.file.writeAll(msg) catch {};` | Logs "file.writeAll failed" |
| 63 | `posix.write(2, msg) catch {};` | Logs "posix.write stderr failed" |
| 74 | `writer.writeAll("HEX: ") catch {};` | Logs "writeAll HEX prefix failed" |
| 77 | `writer.print(...) catch {};` | Logs "hex byte print failed" |
| 79 | `writer.writeAll("\n     ") catch {};` | Logs "writeAll newline indent failed" |
| 83 | `writer.writeAll("...") catch {};` | Logs "writeAll truncation marker failed" |
| 87 | `self.file.writeAll(msg) catch {};` | Logs "hexDump file.writeAll failed" |

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)