### PR TITLE
fix(tri-api): replace 6 empty catch {} with error logging in main.zig

### DIFF
--- a/src/tri-api/main.zig
+++ b/src/tri-api/main.zig
@@ -95,8 +95,12 @@ pub fn main() !void {
             const stdout_file = std.fs.File.stdout();
             var write_buf: [4096]u8 = undefined;
             var w = stdout_file.writer(&write_buf);
-            std.Io.Writer.writeAll(&w.interface, list) catch {};
-            w.end() catch {};
+            std.Io.Writer.writeAll(&w.interface, list) catch |err| {
+                std.log.debug("tri-api/main: failed to write session list: {}", .{err});
+            };
+            w.end() catch |err| {
+                std.log.debug("tri-api/main: failed to flush stdout: {}", .{err});
+            };
         } else {
             std.debug.print("No sessions found.\n", .{});
         }
@@ -117,7 +121,9 @@ pub fn main() !void {
     const system_prompt = blk: {
         var parts = std.ArrayList(u8).empty;
         if (claude_md.loadSystemPrompt(allocator)) |sp| {
-            parts.appendSlice(allocator, sp) catch {};
+            parts.appendSlice(allocator, sp) catch |err| {
+                std.log.warn("tri-api/main: failed to append system prompt: {}", .{err});
+            };
             allocator.free(sp);
         }
         if (mem.load()) |mem_content| {
@@ -367,8 +373,12 @@ fn runAgenticLoop(
                         ui.printAssistant(text);
                     } else {
                         const stdout = std.fs.File.stdout();
-                        stdout.writeAll(text) catch {};
-                        stdout.writeAll("\n") catch {};
+                        stdout.writeAll(text) catch |err| {
+                            std.log.debug("tri-api/main: failed to write text output: {}", .{err});
+                        };
+                        stdout.writeAll("\n") catch |err| {
+                            std.log.debug("tri-api/main: failed to write newline: {}", .{err});
+                        };
                     }
                 },
                 .tool_use => |tool| {
@@ -490,7 +500,9 @@ fn httpPost(allocator: std.mem.Allocator, api_key: []const u8, url: []const u8, 
     var body_writer = req.sendBodyUnflushed(&.{}) catch return error.ConnectionFailed;
     body_writer.writer.writeAll(body) catch return error.ConnectionFailed;
     body_writer.end() catch return error.ConnectionFailed;
-    if (req.connection) |conn| conn.flush() catch {};
+    if (req.connection) |conn| conn.flush() catch |err| {
+        std.log.debug("tri-api/main: failed to flush connection: {}", .{err});
+    };
 
     var redirect_buf: [0]u8 = .{};
     var response = req.receiveHead(&redirect_buf) catch return error.ConnectionFailed;


### PR DESCRIPTION
## Summary
- Replace 6 empty `catch {}` blocks in `src/tri-api/main.zig` with proper error logging
- Use `std.log.debug` for cosmetic/output failures (session list, stdout, connection flush)
- Use `std.log.warn` for data-loss risks (system prompt append failure)

## Changes
| Line | Before | After |
|------|--------|-------|
| 98-99 | `catch {}` | `catch |err| { std.log.debug(...) }` |
| 120 | `catch {}` | `catch |err| { std.log.warn(...) }` |
| 370-371 | `catch {}` | `catch |err| { std.log.debug(...) }` |
| 493 | `catch {}` | `catch |err| { std.log.debug(...) }` |

## Test plan
- [x] `zig fmt src/` passes
- [x] `zig ast-check src/tri-api/main.zig` passes
- [x] Commit references issue #241

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)