### PR TITLE
fix(bot): replace 5 empty catch {} with error logging in handlers.zig

### DIFF
--- a/tools/mcp/trinity_mcp/bot/handlers.zig
+++ b/tools/mcp/trinity_mcp/bot/handlers.zig
@@ -125,7 +125,9 @@ pub fn handleStatus(allocator: std.mem.Allocator, config: BotConfig) void {
     const before_changes = out.items.len;
     appendCommandOutput(allocator, &out, config.project_root, &.{ "git", "status", "--short" });
     if (out.items.len == before_changes) {
-        out.appendSlice(allocator, "(clean)\n") catch {};
+        out.appendSlice(allocator, "(clean)\n") catch |err| {
+            std.log.debug("handlers: failed to append clean status: {}", .{err});
+        };
     }
 
     if (out.items.len > 20) {
@@ -331,7 +333,9 @@ pub fn handleSessions(allocator: std.mem.Allocator, config: BotConfig) void {
     if (count == 0) {
         telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xf0\x9f\x93\x8b No sessions yet. Use /ask to start one.");
     } else {
-        out.appendSlice(allocator, "\nUse /resume <id> to continue a session.") catch {};
+        out.appendSlice(allocator, "\nUse /resume <id> to continue a session.") catch |err| {
+            std.log.debug("handlers: failed to append resume hint: {}", .{err});
+        };
         telegram_api.sendLongMessage(allocator, config, out.items);
     }
 }
@@ -453,17 +457,23 @@ fn appendCommandOutput(allocator: std.mem.Allocator, out: *std.ArrayList(u8), cw
         .cwd = cwd,
         .max_output_bytes = 64 * 1024,
     }) catch {
-        out.appendSlice(allocator, "(error)\n") catch {};
+        out.appendSlice(allocator, "(error)\n") catch |err| {
+            std.log.debug("handlers: failed to append error marker: {}", .{err});
+        };
         return;
     };
     defer allocator.free(result.stdout);
     defer allocator.free(result.stderr);
 
     if (result.stdout.len > 0) {
-        out.appendSlice(allocator, result.stdout) catch {};
+        out.appendSlice(allocator, result.stdout) catch |err| {
+            std.log.warn("handlers: failed to append command output: {}", .{err});
+        };
         // Ensure trailing newline
         if (result.stdout[result.stdout.len - 1] != '\n') {
-            out.appendSlice(allocator, "\n") catch {};
+            out.appendSlice(allocator, "\n") catch |err| {
+                std.log.debug("handlers: failed to append newline: {}", .{err});
+            };
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace 5 empty `catch {}` blocks with proper error logging in `tools/mcp/trinity_mcp/bot/handlers.zig`
- Use `std.log.debug` for 4 non-critical append failures (clean status, resume hint, error marker, newline)
- Use `std.log.warn` for 1 potentially important failure (command output append - data loss scenario)

## Changes
| Line | Context | Log Level |
|------|---------|-----------|
| 128 | `(clean)\n` append | debug |
| 334 | resume hint append | debug |
| 456 | `(error)\n` append | debug |
| 463 | command stdout append | warn |
| 466 | newline append | debug |

## Test plan
- [x] `zig fmt tools/mcp/trinity_mcp/bot/handlers.zig` - no changes
- [x] `zig build` - binaries compiled successfully (trinity-mcp, tri-bot, tri-api)
- [x] Manual code review - all 5 catch blocks replaced with proper pattern

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)