### PR TITLE
fix(bot): replace 3 empty catch {} with error logging in claude_stream.zig

### DIFF
--- a/tools/mcp/trinity_mcp/bot/claude_stream.zig
+++ b/tools/mcp/trinity_mcp/bot/claude_stream.zig
@@ -89,8 +89,12 @@ pub fn runStreaming(
         telegram_api.sendMessage(allocator, config.bot_token, config.chat_id, "\xe2\x9d\x8c Write failed");
         return;
     };
-    bw.end() catch {};
-    if (req.connection) |conn| conn.flush() catch {};
+    bw.end() catch |err| {
+        std.log.debug("claude_stream: bw.end() failed: {}", .{err});
+    };
+    if (req.connection) |conn| conn.flush() catch |err| {
+        std.log.debug("claude_stream: conn.flush() failed: {}", .{err});
+    };
 
     // Receive response head
     var redirect_buf: [0]u8 = .{};
@@ -154,7 +158,9 @@ pub fn runStreaming(
                 if (line.len > 6 and std.mem.eql(u8, line[0..6], "data: ")) {
                     const json = line[6..];
                     if (extractTextDelta(json)) |text_val| {
-                        appendJsonUnescaped(&text_buf, allocator, text_val) catch {};
+                        appendJsonUnescaped(&text_buf, allocator, text_val) catch |err| {
+                            std.log.warn("claude_stream: appendJsonUnescaped failed: {}", .{err});
+                        };
                     }
                 }
                 line_len = 0;


### PR DESCRIPTION
## Summary

- Replace 3 empty `catch {}` blocks with proper error logging in `tools/mcp/trinity_mcp/bot/claude_stream.zig`
- Use `std.log.debug` for HTTP stream operations (`bw.end()`, `conn.flush()`)
- Use `std.log.warn` for JSON parsing operation (`appendJsonUnescaped`)

## Changes

| Line | Before | After |
|------|--------|-------|
| 92 | `bw.end() catch {};` | `bw.end() catch \|err\| { std.log.debug(...) };` |
| 93 | `conn.flush() catch {};` | `conn.flush() catch \|err\| { std.log.debug(...) };` |
| 157 | `appendJsonUnescaped(...) catch {};` | `appendJsonUnescaped(...) catch \|err\| { std.log.warn(...) };` |

## Test plan

- [x] `zig fmt` passes
- [x] `zig build` compiles successfully
- [x] trinity-mcp binary created (49MB)

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)