### PR TITLE
fix(tri-api): catch unreachable on URI parse in httpPost — crashes on malformed URL

### DIFF
--- a/src/tri-api/main.zig
+++ b/src/tri-api/main.zig
@@ -485,7 +485,10 @@ fn httpPost(allocator: std.mem.Allocator, api_key: []const u8, url: []const u8, 
     var client = std.http.Client{ .allocator = allocator };
     defer client.deinit();
 
-    const uri = std.Uri.parse(url) catch unreachable;
+    const uri = std.Uri.parse(url) catch |err| {
+        std.log.err("tri-api: invalid API URL '{s}': {}", .{ url, err });
+        return error.InvalidUri;
+    };
 
     var req = client.request(.POST, uri, .{
         .extra_headers = &.{


### PR DESCRIPTION
## Summary

- Replace `catch unreachable` with proper error handling in `httpPost` function
- Malformed API URLs (missing scheme, bad characters) now log an error and return `error.InvalidUri` instead of panicking the entire tri-api process

## Test plan

- [x] `zig build-exe -fno-emit-bin src/tri-api/main.zig` compiles clean
- [ ] No panics on malformed URL input

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)