### PR TITLE
fix(tri-api): catch unreachable on address parse in perplexity_bridge.zig

### DIFF
--- a/src/tri-api/perplexity_bridge.zig
+++ b/src/tri-api/perplexity_bridge.zig
@@ -55,7 +55,10 @@ pub const Bridge = struct {
     pub fn serve(self: *Bridge) !void {
         self.ensureQueueDir();
 
-        const address = std.net.Address.parseIp4("0.0.0.0", self.port) catch unreachable;
+        const address = std.net.Address.parseIp4("0.0.0.0", self.port) catch |err| {
+            std.log.err("perplexity_bridge: failed to parse address: {}", .{err});
+            return error.SocketError;
+        };
         var server = try address.listen(.{ .reuse_address = true });
         defer server.deinit();
 


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with proper error handling for socket address parsing in `perplexity_bridge.zig`
- Prevents potential panic on invalid port configuration

## Changes
- `src/tri-api/perplexity_bridge.zig`: Added error logging and graceful return of `error.SocketError` instead of panicking

Closes #262

🤖 Generated with [Claude Code](https://claude.com/claude-code)