### PR TITLE
fix(jit): catch unreachable on cache getOrPut in jit.zig — OOM crash

### DIFF
--- a/src/b2t/jit.zig
+++ b/src/b2t/jit.zig
@@ -1448,8 +1448,8 @@ pub const InlineCacheManager = struct {
     }
 
     /// Get or create monomorphic cache for a call site
-    pub fn getMonomorphicCache(self: *InlineCacheManager, call_site: u32) *MonomorphicIC {
-        const result = self.monomorphic_caches.getOrPut(call_site) catch unreachable;
+    pub fn getMonomorphicCache(self: *InlineCacheManager, call_site: u32) std.mem.Allocator.Error!*MonomorphicIC {
+        const result = try self.monomorphic_caches.getOrPut(call_site);
         if (!result.found_existing) {
             result.value_ptr.* = MonomorphicIC.init();
         }
@@ -1457,8 +1457,8 @@ pub const InlineCacheManager = struct {
     }
 
     /// Get or create polymorphic cache for a call site
-    pub fn getPolymorphicCache(self: *InlineCacheManager, call_site: u32) *PolymorphicIC {
-        const result = self.polymorphic_caches.getOrPut(call_site) catch unreachable;
+    pub fn getPolymorphicCache(self: *InlineCacheManager, call_site: u32) std.mem.Allocator.Error!*PolymorphicIC {
+        const result = try self.polymorphic_caches.getOrPut(call_site);
         if (!result.found_existing) {
             result.value_ptr.* = PolymorphicIC.init();
         }


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with `try` on HashMap getOrPut operations in `src/b2t/jit.zig`
- Changed `getMonomorphicCache` and `getPolymorphicCache` to return error unions (`std.mem.Allocator.Error!*T`)

## Problem
OOM during cache growth would panic instead of degrading gracefully.

## Solution
Functions now properly propagate allocation errors to callers, allowing graceful handling.

Closes #267