### PR TITLE
fix(needle): catch unreachable → try in ann_ivf_pq.zig — 4 OOM crash sites

### DIFF
--- a/src/needle/ann_ivf_pq.zig
+++ b/src/needle/ann_ivf_pq.zig
@@ -83,7 +83,7 @@ pub const IVFPQIndex = struct {
     pub fn init(allocator: std.mem.Allocator, config: IVFConfig) !Self {
         return Self{
             .config = config,
-            .voronoi_cells = std.ArrayList(VoronoiCell).initCapacity(allocator, 64) catch unreachable,
+            .voronoi_cells = try std.ArrayList(VoronoiCell).initCapacity(allocator, 64),
             .pq_codebook = null,
             .pq_codes = std.AutoHashMap(u64, PQCode).init(allocator),
             .vectors = std.AutoHashMap(u64, []f32).init(allocator),
@@ -161,7 +161,7 @@ pub const IVFPQIndex = struct {
             const cell = VoronoiCell{
                 .center_id = @intCast(i),
                 .center = centroid,
-                .vector_ids = std.ArrayList(u64).initCapacity(self.allocator, 32) catch unreachable,
+                .vector_ids = try std.ArrayList(u64).initCapacity(self.allocator, 32),
             };
             try self.voronoi_cells.append(self.allocator, cell);
         }
@@ -346,7 +346,7 @@ pub const IVFPQIndex = struct {
         }
 
         // Find nprobe nearest cells to query
-        var cell_dists = std.ArrayList(struct { cell_idx: usize, dist: f32 }).initCapacity(self.allocator, 64) catch unreachable;
+        var cell_dists = try std.ArrayList(struct { cell_idx: usize, dist: f32 }).initCapacity(self.allocator, 64);
         defer cell_dists.deinit(self.allocator);
 
         for (self.voronoi_cells.items, 0..) |*cell, cell_idx| {
@@ -364,7 +364,7 @@ pub const IVFPQIndex = struct {
         }.compare);
 
         // Collect candidates from nearby cells
-        var candidates = std.ArrayList(u64).initCapacity(self.allocator, 256) catch unreachable;
+        var candidates = try std.ArrayList(u64).initCapacity(self.allocator, 256);
         defer candidates.deinit(self.allocator);
 
         for (cell_dists.items[0..nprobe]) |item| {


### PR DESCRIPTION
## Summary
- Replace 4 occurrences of `catch unreachable` with `try` in `src/needle/ann_ivf_pq.zig`
- Ensures OOM during vector indexing returns an error instead of panicking

## Changes
| Line | Function | Fix |
|------|----------|-----|
| 86 | `init()` | `voronoi_cells` initCapacity |
| 164 | `kMeansClustering()` | `vector_ids` initCapacity |
| 349 | `search()` | `cell_dists` initCapacity |
| 367 | `search()` | `candidates` initCapacity |

All containing functions already return error unions, so `try` propagates errors correctly.

## Test plan
- [x] `zig ast-check src/needle/ann_ivf_pq.zig` passes
- [x] No `catch unreachable` remains in the file
- [x] File compiles clean

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)