### PR TITLE
fix(needle): catch unreachable → try in ann_benchmark.zig and ann_utils.zig

### DIFF
--- a/src/needle/ann_benchmark.zig
+++ b/src/needle/ann_benchmark.zig
@@ -71,9 +71,9 @@ pub const BenchmarkSuite = struct {
 
     const Self = @This();
 
-    pub fn init(allocator: std.mem.Allocator, config: BenchmarkConfig) Self {
+    pub fn init(allocator: std.mem.Allocator, config: BenchmarkConfig) !Self {
         return Self{
-            .results = std.ArrayList(BenchmarkResult).initCapacity(allocator, 32) catch unreachable,
+            .results = try std.ArrayList(BenchmarkResult).initCapacity(allocator, 32),
             .config = config,
             .timestamp = std.time.timestamp(),
             .allocator = allocator,
@@ -107,7 +107,7 @@ pub fn generateDataset(
     const queries = try ann_utils.generateRandomVectors(allocator, 100, dim, seed + 1);
 
     // Compute ground truth using brute force
-    var ground_truth = std.ArrayList(GroundTruth).initCapacity(allocator, 100) catch unreachable;
+    var ground_truth = try std.ArrayList(GroundTruth).initCapacity(allocator, 100);
     defer {
         for (ground_truth.items) |*gt| gt.deinit(allocator);
         ground_truth.deinit(allocator);
@@ -115,7 +115,7 @@ pub fn generateDataset(
 
     for (queries, 0..) |query, q_id| {
         const DistItem = struct { id: u64, dist: f32 };
-        var distances = std.ArrayList(DistItem).initCapacity(allocator, vectors.len) catch unreachable;
+        var distances = try std.ArrayList(DistItem).initCapacity(allocator, vectors.len);
         defer {
             for (distances.items) |*d| {
                 _ = d;
@@ -212,7 +212,7 @@ pub fn benchmarkAlgorithm(
         .hnsw => return error.NotImplemented, // Use existing HNSW
     }
 
-    build_timer.stop();
+    try build_timer.stop();
     const build_time_ms: f64 = @floatFromInt(build_timer.elapsedMs());
 
     // Get stats after build
@@ -233,7 +233,7 @@ pub fn benchmarkAlgorithm(
 
     // Search phase (simplified - single run)
     // Rebuild for search test
-    var search_times = std.ArrayList(f64).initCapacity(allocator, config.measured_runs) catch unreachable;
+    var search_times = try std.ArrayList(f64).initCapacity(allocator, config.measured_runs);
     defer search_times.deinit(allocator);
 
     const num_search_runs = @min(config.measured_runs, queries.len);
@@ -283,7 +283,7 @@ pub fn benchmarkAlgorithm(
             .ivf_pq => try idx.ivf.search(query, 10, allocator),
             .hnsw => return error.NotImplemented,
         };
-        search_timer.stop();
+        try search_timer.stop();
 
         // Clean up results
         for (results) |r| {
@@ -323,7 +323,7 @@ pub fn benchmarkAlgorithm(
 
 /// Run full benchmark suite
 pub fn runBenchmarkSuite(allocator: std.mem.Allocator, config: BenchmarkConfig) !BenchmarkSuite {
-    var suite = BenchmarkSuite.init(allocator, config);
+    var suite = try BenchmarkSuite.init(allocator, config);
 
     const algorithms = [_]ann_interface.ANNType{ .brute, .ivf_pq }; // LSH temporarily disabled due to VSA integration issue
 

--- a/src/needle/ann_utils.zig
+++ b/src/needle/ann_utils.zig
@@ -233,8 +233,8 @@ pub const Timer = struct {
         };
     }
 
-    pub fn stop(self: *Timer) void {
-        self.end_time = std.time.Instant.now() catch unreachable;
+    pub fn stop(self: *Timer) !void {
+        self.end_time = try std.time.Instant.now();
     }
 
     pub fn elapsedMs(self: *const Timer) u64 {


### PR DESCRIPTION
## Summary

- Replace all 5 `catch unreachable` with proper error propagation using `try`
- Ensures OOM and timer failures return errors instead of panicking

## Changes

**src/needle/ann_benchmark.zig** (4 fixes):
- Line 76: `BenchmarkSuite.init()` → returns `!Self`
- Line 110: `generateDataset()` → `try initCapacity`
- Line 118: `generateDataset()` → `try initCapacity`
- Line 236: `benchmarkAlgorithm()` → `try initCapacity`
- Lines 215, 286: Updated `timer.stop()` calls to `try`

**src/needle/ann_utils.zig** (1 fix):
- Line 237: `Timer.stop()` → returns `!void`

## Test Plan

- [x] `zig ast-check` passes on both files
- [x] `zig build -j1` completes (75/82 steps, failures unrelated to this change)

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)