### PR TITLE
fix(needle): catch unreachable → try in hnsw.zig, vsa.zig, autonomous_refactor.zig

### DIFF
--- a/src/needle/autonomous_refactor.zig
+++ b/src/needle/autonomous_refactor.zig
@@ -280,9 +280,9 @@ pub const AutonomousRefactorEngine = struct {
         errdefer intent.deinit(allocator);
 
         // Simple keyword-based classification (can be enhanced with ML)
-        intent.confidence = classifyConfidence(description);
-        intent.scope = classifyScope(description);
-        intent.safety_level = classifySafety(description);
+        intent.confidence = try classifyConfidence(description);
+        intent.scope = try classifyScope(description);
+        intent.safety_level = try classifySafety(description);
 
         return intent;
     }
@@ -412,8 +412,8 @@ pub const AutonomousRefactorEngine = struct {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /// Classify confidence based on description keywords
-fn classifyConfidence(description: []const u8) f32 {
-    var lower = toLower(description);
+fn classifyConfidence(description: []const u8) !f32 {
+    var lower = try toLower(description);
     defer lower.deinit(std.heap.page_allocator);
 
     // Clear intent keywords
@@ -435,8 +435,8 @@ fn classifyConfidence(description: []const u8) f32 {
 }
 
 /// Classify scope based on description
-fn classifyScope(description: []const u8) RefactorScope {
-    var lower = toLower(description);
+fn classifyScope(description: []const u8) !RefactorScope {
+    var lower = try toLower(description);
     defer lower.deinit(std.heap.page_allocator);
 
     if (std.mem.indexOf(u8, lower.items, "module") != null or
@@ -457,8 +457,8 @@ fn classifyScope(description: []const u8) RefactorScope {
 }
 
 /// Classify safety level based on description
-fn classifySafety(description: []const u8) SafetyLevel {
-    var lower = toLower(description);
+fn classifySafety(description: []const u8) !SafetyLevel {
+    var lower = try toLower(description);
     defer lower.deinit(std.heap.page_allocator);
 
     if (std.mem.indexOf(u8, lower.items, "critical") != null or
@@ -483,10 +483,10 @@ fn classifySafety(description: []const u8) SafetyLevel {
 }
 
 /// Convert string to lowercase for keyword matching
-fn toLower(s: []const u8) std.ArrayList(u8) {
+fn toLower(s: []const u8) !std.ArrayList(u8) {
     var result = std.ArrayList(u8).empty;
     for (s) |c| {
-        result.append(std.heap.page_allocator, std.ascii.toLower(c)) catch unreachable;
+        try result.append(std.heap.page_allocator, std.ascii.toLower(c));
     }
     return result;
 }

--- a/src/needle/hnsw.zig
+++ b/src/needle/hnsw.zig
@@ -118,7 +118,7 @@ pub const HNSWIndex = struct {
         // Initialize layer lists
         try new_node.layers.ensureTotalCapacity(self.allocator, level + 1);
         for (0..level + 1) |_| {
-            new_node.layers.append(self.allocator, std.ArrayList(usize).empty) catch unreachable;
+            try new_node.layers.append(self.allocator, std.ArrayList(usize).empty);
         }
 
         try self.nodes.append(self.allocator, new_node);

--- a/src/needle/vsa.zig
+++ b/src/needle/vsa.zig
@@ -533,12 +533,12 @@ pub fn unbindVSA(bound: *HybridBigInt, key: *HybridBigInt) HybridBigInt {
 }
 
 /// Bundle multiple vectors (majority vote) - uses HybridBigInt
-pub fn bundleVSA(vectors: []const *HybridBigInt) HybridBigInt {
+pub fn bundleVSA(vectors: []const *HybridBigInt) !HybridBigInt {
     // Convert slice to pointers slice for bundleN
     var pointers = std.ArrayList(*HybridBigInt).init(std.heap.page_allocator);
     defer pointers.deinit();
     for (vectors) |v| {
-        pointers.append(v) catch unreachable;
+        try pointers.append(v);
     }
     return trinity_vsa.bundleN(pointers.items);
 }


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with `try` in three needle files for proper error handling
- Update function signatures to return error unions where needed
- Propagate errors through classification helper functions

## Changes
| File | Line | Fix |
|------|------|-----|
| `src/needle/hnsw.zig` | 121 | `append` now uses `try` |
| `src/needle/vsa.zig` | 541 | `bundleVSA` now returns `!HybridBigInt` |
| `src/needle/autonomous_refactor.zig` | 489 | `toLower` now returns `!std.ArrayList(u8)` |

The `autonomous_refactor.zig` changes required updating:
- `classifyConfidence` → returns `!f32`
- `classifyScope` → returns `!RefactorScope`  
- `classifySafety` → returns `!SafetyLevel`
- `analyzeIntent` calls now use `try`

## Verification
All three files compile clean with `zig build-obj`.

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)