### PR TITLE
fix(needle): catch unreachable → try in ANN files

### DIFF
--- a/src/needle/ann_brute_simd.zig
+++ b/src/needle/ann_brute_simd.zig
@@ -38,7 +38,7 @@ pub const BruteIndex = struct {
             .config = config,
             .vectors = std.AutoHashMap(u64, []f32).init(allocator),
             .symbol_ids = std.AutoHashMap(u64, []const u8).init(allocator),
-            .vector_list = std.ArrayList(u64).initCapacity(allocator, 64) catch unreachable,
+            .vector_list = try std.ArrayList(u64).initCapacity(allocator, 64),
             .allocator = allocator,
             .total_vectors = 0,
         };

--- a/src/needle/ann_lsh_ternary.zig
+++ b/src/needle/ann_lsh_ternary.zig
@@ -81,7 +81,7 @@ pub const LSHIndex = struct {
     pub fn init(allocator: std.mem.Allocator, config: LSHConfig) !Self {
         var index = Self{
             .config = config,
-            .hash_tables = std.ArrayList(LSHHashTable).initCapacity(allocator, config.n_tables) catch unreachable,
+            .hash_tables = try std.ArrayList(LSHHashTable).initCapacity(allocator, config.n_tables),
             .ternary_vectors = std.AutoHashMap(u64, TernaryVector).init(allocator),
             .float32_cache = std.AutoHashMap(u64, []f32).init(allocator),
             .allocator = allocator,
@@ -162,7 +162,7 @@ pub const LSHIndex = struct {
         const allocator = self.allocator;
 
         // For random projection: project + ternarize for each hash function
-        var hash_parts = std.ArrayList([]const u8).initCapacity(allocator, self.config.n_hashes) catch unreachable;
+        var hash_parts = try std.ArrayList([]const u8).initCapacity(allocator, self.config.n_hashes);
         defer {
             for (hash_parts.items) |part| allocator.free(part);
             hash_parts.deinit(allocator);
@@ -184,7 +184,7 @@ pub const LSHIndex = struct {
         }
 
         // Combine all parts into single hash key (simple concatenation)
-        var combined = std.ArrayList(u8).initCapacity(allocator, self.config.n_hashes * 2) catch unreachable;
+        var combined = try std.ArrayList(u8).initCapacity(allocator, self.config.n_hashes * 2);
         defer combined.deinit(allocator);
         for (hash_parts.items) |part| {
             try combined.appendSlice(allocator, part);
@@ -217,7 +217,7 @@ pub const LSHIndex = struct {
 
             const entry = try table.buckets.getOrPut(hash_key);
             if (!entry.found_existing) {
-                entry.value_ptr.* = std.ArrayList(u64).initCapacity(self.allocator, 8) catch unreachable;
+                entry.value_ptr.* = try std.ArrayList(u64).initCapacity(self.allocator, 8);
             }
             try entry.value_ptr.append(self.allocator, id);
         }
@@ -263,7 +263,7 @@ pub const LSHIndex = struct {
         const query_ternary = try self.float32ToTernary(query);
 
         // Compute Hamming distances for all candidates
-        var results_list = std.ArrayList(ann_interface.ANNResult).initCapacity(result_allocator, @min(actual_k, candidates_set.count())) catch unreachable;
+        var results_list = try std.ArrayList(ann_interface.ANNResult).initCapacity(result_allocator, @min(actual_k, candidates_set.count()));
 
         var candidate_iter = candidates_set.keyIterator();
         while (candidate_iter.next()) |id_ptr| {


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with `try` for proper error propagation in two ANN files
- `ann_brute_simd.zig`: 1 occurrence (line 41)
- `ann_lsh_ternary.zig`: 5 occurrences (lines 84, 165, 187, 220, 266)

## Details
All `ArrayList.initCapacity` calls now properly propagate allocation errors instead of crashing on OOM.

All containing functions already return error unions, so no signature changes were needed.

## Verification
- `zig ast-check` passed for both files
- `zig test src/needle/ann_brute_simd.zig` - 9/9 tests passed

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)