### PR TITLE
fix(jit): catch unreachable → try on Timer.start

### DIFF
--- a/src/jit_arm64.zig
+++ b/src/jit_arm64.zig
@@ -1640,7 +1640,7 @@ test "ARM64 NEON SIMD benchmark vs scalar" {
     const simd_func = try simd_compiler.finalize();
 
     // Benchmark scalar
-    var timer = std.time.Timer.start() catch unreachable;
+    var timer = try std.time.Timer.start();
     var scalar_result: i64 = 0;
     for (0..iterations) |_| {
         scalar_result = scalar_func(@ptrCast(&a), @ptrCast(&b));
@@ -1830,7 +1830,7 @@ test "ARM64 hybrid benchmark vs pure scalar" {
     const hybrid_func = try hybrid_compiler.finalize();
 
     // Benchmark scalar
-    var timer = std.time.Timer.start() catch unreachable;
+    var timer = try std.time.Timer.start();
     var scalar_result: i64 = 0;
     for (0..iterations) |_| {
         scalar_result = scalar_func(@ptrCast(&a), @ptrCast(&b));
@@ -2012,7 +2012,7 @@ test "ARM64 SIMD bind benchmark vs scalar" {
     const scalar_func = try scalar_compiler.finalize();
 
     // Benchmark SIMD
-    var timer = std.time.Timer.start() catch unreachable;
+    var timer = try std.time.Timer.start();
     for (0..iterations) |_| {
         // Reset a for fair comparison
         for (0..dim) |i| {
@@ -2103,7 +2103,7 @@ test "ARM64 fused cosine benchmark vs 3x dot" {
     }
 
     // Benchmark fused
-    var timer = std.time.Timer.start() catch unreachable;
+    var timer = try std.time.Timer.start();
     var fused_result: f64 = 0;
     for (0..iterations) |_| {
         const bits = fused_func(@ptrCast(&a), @ptrCast(&b));

--- a/src/jit_unified.zig
+++ b/src/jit_unified.zig
@@ -407,7 +407,7 @@ test "Unified JIT benchmark" {
         b[i] = @intCast(@as(i32, @intCast((i + 1) % 3)) - 1);
     }
 
-    var timer = std.time.Timer.start() catch unreachable;
+    var timer = try std.time.Timer.start();
     var result: i64 = 0;
     for (0..iterations) |_| {
         result = func(@ptrCast(&a), @ptrCast(&b));


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with `try` on `std.time.Timer.start()` calls in jit_arm64.zig (4 occurrences) and jit_unified.zig (1 occurrence)
- Timer.start() can fail on some platforms; using `catch unreachable` would panic instead of propagating the error gracefully

## Files Changed
- `src/jit_arm64.zig` — lines 1643, 1833, 2015, 2106
- `src/jit_unified.zig` — line 410

## Test Plan
- [x] `zig test src/jit_arm64.zig` — All 24 tests passed
- [x] `zig test src/jit_unified.zig` — All 36 tests passed

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)