### PR TITLE
fix(vsa): catch unreachable → try in 10k_vsa.zig — 9 bounds-guaranteed sites

### DIFF
--- a/src/models/tqnn/tqnn_inference.zig
+++ b/src/models/tqnn/tqnn_inference.zig
@@ -189,7 +189,7 @@ pub const TQNNVSAInference = struct {
 
         // Initialize random VSA weights
         var rng = std.Random.DefaultPrng.init(@intCast(std.time.nanoTimestamp()));
-        const weights = vsa10k.HyperVector10K.random(&rng);
+        const weights = try vsa10k.HyperVector10K.random(&rng);
 
         return .{
             .layer1 = layer1,
@@ -222,10 +222,10 @@ pub const TQNNVSAInference = struct {
         try self.map_to_vsa();
 
         // Step 3: VSA Bind operation with weights (result stored in output)
-        _ = self.vsa_bind();
+        _ = try self.vsa_bind();
 
         // Step 4: Compute similarity (for monitoring)
-        const similarity = self.compute_similarity();
+        const similarity = try self.compute_similarity();
 
         return .{
             .quantum_state = self.layer1.quantum_state(),
@@ -249,23 +249,23 @@ pub const TQNNVSAInference = struct {
             var j: usize = 0;
             while (j < expansion) : (j += 1) {
                 const vsa_idx = (i * expansion + j) % vsa10k.DIM_10K;
-                vsa_input.set(vsa_idx, trit) catch unreachable; // vsa_idx < DIM_10K by construction
+                try vsa_input.set(vsa_idx, trit);
             }
         }
 
         // Store in self.output for binding
         for (0..vsa10k.DIM_10K) |k| {
-            self.output[k] = @as(qutrit.Trit, @intCast(vsa_input.get(k) catch unreachable)); // k < DIM_10K by construction
+            self.output[k] = @as(qutrit.Trit, @intCast(try vsa_input.get(k)));
         }
     }
 
     /// VSA Bind operation
-    fn vsa_bind(self: *const Self) vsa10k.HyperVector10K {
+    fn vsa_bind(self: *const Self) error{IndexOutOfBounds}!vsa10k.HyperVector10K {
         var result = vsa10k.HyperVector10K.zero();
 
         for (0..vsa10k.DIM_10K) |i| {
             const a = self.output[i];
-            const b = self.weights.get(i) catch unreachable; // i < DIM_10K by construction
+            const b = try self.weights.get(i);
 
             // Trit multiplication for bind
             const result_trit: qutrit.Trit = if (a == 0 or b == 0)
@@ -275,21 +275,21 @@ pub const TQNNVSAInference = struct {
             else
                 -1;
 
-            result.set(i, result_trit) catch unreachable; // i < DIM_10K by construction
+            try result.set(i, result_trit);
         }
 
         return result;
     }
 
     /// Compute similarity between output and weights
-    fn compute_similarity(self: *const Self) u16 {
+    fn compute_similarity(self: *const Self) error{IndexOutOfBounds}!u16 {
         var dot_product: i32 = 0;
         var norm_a: i32 = 0;
         var norm_b: i32 = 0;
 
         for (0..vsa10k.DIM_10K) |i| {
             const a = self.output[i];
-            const b = self.weights.get(i) catch unreachable; // i < DIM_10K by construction
+            const b = try self.weights.get(i);
 
             dot_product += @as(i32, a) * @as(i32, b);
             norm_a += @as(i32, a) * @as(i32, a);

--- a/src/vsa/10k_vsa.zig
+++ b/src/vsa/10k_vsa.zig
@@ -54,7 +54,7 @@ pub const HyperVector10K = struct {
     }
 
     /// Create a random vector
-    pub fn random(rng: *std.Random.DefaultPrng) Self {
+    pub fn random(rng: *std.Random.DefaultPrng) error{IndexOutOfBounds}!Self {
         var self = Self.zero();
         var i: usize = 0;
         while (i < DIM_10K) : (i += 1) {
@@ -65,7 +65,7 @@ pub const HyperVector10K = struct {
                 2 => TRIT_NEG,
                 else => TRIT_POS,
             };
-            self.set(i, trit_val) catch unreachable; // i < DIM_10K by construction
+            try self.set(i, trit_val);
         }
         return self;
     }
@@ -143,31 +143,31 @@ pub const HyperVector10K = struct {
     }
 
     /// Bundle operation (majority vote)
-    pub fn bundle(a: *const Self, b: *const Self) Self {
+    pub fn bundle(a: *const Self, b: *const Self) error{IndexOutOfBounds}!Self {
         var result = Self.zero();
 
         var i: usize = 0;
         while (i < DIM_10K) : (i += 1) {
-            const a_trit = a.get(i) catch unreachable; // i < DIM_10K by construction
-            const b_trit = b.get(i) catch unreachable;
+            const a_trit = try a.get(i);
+            const b_trit = try b.get(i);
 
             const r_trit: Trit = tritBundle(a_trit, b_trit);
-            result.set(i, r_trit) catch unreachable;
+            try result.set(i, r_trit);
         }
 
         return result;
     }
 
     /// Cosine similarity (scaled to 0-65535)
-    pub fn cosineSimilarity(a: *const Self, b: *const Self) u16 {
+    pub fn cosineSimilarity(a: *const Self, b: *const Self) error{IndexOutOfBounds}!u16 {
         var dot_product: i64 = 0;
         var norm_a: i64 = 0;
         var norm_b: i64 = 0;
 
         var i: usize = 0;
         while (i < DIM_10K) : (i += 1) {
-            const a_trit = a.get(i) catch unreachable; // i < DIM_10K by construction
-            const b_trit = b.get(i) catch unreachable;
+            const a_trit = try a.get(i);
+            const b_trit = try b.get(i);
 
             dot_product += @as(i64, a_trit) * @as(i64, b_trit);
             norm_a += @as(i64, a_trit) * @as(i64, a_trit);
@@ -185,26 +185,26 @@ pub const HyperVector10K = struct {
     }
 
     /// Permutation (cyclic shift)
-    pub fn permute(self: *const Self, shift: u16) Self {
+    pub fn permute(self: *const Self, shift: u16) error{IndexOutOfBounds}!Self {
         var result = Self.zero();
         const effective_shift = @as(usize, @intCast(shift)) % DIM_10K;
 
         var i: usize = 0;
         while (i < DIM_10K) : (i += 1) {
             const src_idx = (i + DIM_10K - effective_shift) % DIM_10K;
-            const trit = self.get(src_idx) catch unreachable; // src_idx < DIM_10K by construction
-            result.set(i, trit) catch unreachable;
+            const trit = try self.get(src_idx);
+            try result.set(i, trit);
         }
 
         return result;
     }
 
     /// Count non-zero trits
-    pub fn countNonZero(self: *const Self) usize {
+    pub fn countNonZero(self: *const Self) error{IndexOutOfBounds}!usize {
         var count: usize = 0;
         var i: usize = 0;
         while (i < DIM_10K) : (i += 1) {
-            if (self.get(i) catch unreachable != TRIT_ZERO) // i < DIM_10K by construction
+            if (try self.get(i) != TRIT_ZERO)
                 count += 1;
         }
         return count;
@@ -277,13 +277,13 @@ pub fn benchmark(_: std.mem.Allocator, iterations: usize) !BenchmarkResult {
     var rng = std.Random.DefaultPrng.init(@intCast(std.time.timestamp()));
 
     // Create test vectors
-    const vec_a = HyperVector10K.random(&rng);
-    const vec_b = HyperVector10K.random(&rng);
+    const vec_a = try HyperVector10K.random(&rng);
+    const vec_b = try HyperVector10K.random(&rng);
 
     // Warmup
     _ = HyperVector10K.bind(&vec_a, &vec_b);
-    _ = HyperVector10K.bundle(&vec_a, &vec_b);
-    _ = HyperVector10K.cosineSimilarity(&vec_a, &vec_b);
+    _ = try HyperVector10K.bundle(&vec_a, &vec_b);
+    _ = try HyperVector10K.cosineSimilarity(&vec_a, &vec_b);
 
     // Benchmark bind
     const bind_start = std.time.nanoTimestamp();
@@ -298,7 +298,7 @@ pub fn benchmark(_: std.mem.Allocator, iterations: usize) !BenchmarkResult {
     const bundle_start = std.time.nanoTimestamp();
     i = 0;
     while (i < iterations) : (i += 1) {
-        _ = HyperVector10K.bundle(&vec_a, &vec_b);
+        _ = try HyperVector10K.bundle(&vec_a, &vec_b);
     }
     const bundle_end = std.time.nanoTimestamp();
     const bundle_ns = @as(f64, @floatFromInt(bundle_end - bundle_start)) / @as(f64, @floatFromInt(iterations));
@@ -307,7 +307,7 @@ pub fn benchmark(_: std.mem.Allocator, iterations: usize) !BenchmarkResult {
     const sim_start = std.time.nanoTimestamp();
     i = 0;
     while (i < iterations) : (i += 1) {
-        _ = HyperVector10K.cosineSimilarity(&vec_a, &vec_b);
+        _ = try HyperVector10K.cosineSimilarity(&vec_a, &vec_b);
     }
     const sim_end = std.time.nanoTimestamp();
     const sim_ns = @as(f64, @floatFromInt(sim_end - sim_start)) / @as(f64, @floatFromInt(iterations));
@@ -360,18 +360,18 @@ pub fn printBenchmark(result: BenchmarkResult) void {
 
 test "HyperVector10K: zero vector" {
     const vec = HyperVector10K.zero();
-    try std.testing.expectEqual(@as(usize, 0), vec.countNonZero());
+    try std.testing.expectEqual(@as(usize, 0), try vec.countNonZero());
 }
 
 test "HyperVector10K: bind identity" {
     var rng = std.Random.DefaultPrng.init(42);
-    const vec = HyperVector10K.random(&rng);
+    const vec = try HyperVector10K.random(&rng);
 
     // Identity vector (all +1)
     var identity = HyperVector10K.zero();
     var i: usize = 0;
     while (i < DIM_10K) : (i += 1) {
-        identity.set(i, TRIT_POS) catch unreachable; // i < DIM_10K by construction
+        try identity.set(i, TRIT_POS);
     }
 
     const result = HyperVector10K.bind(&vec, &identity);
@@ -380,7 +380,7 @@ test "HyperVector10K: bind identity" {
     var match_count: usize = 0;
     i = 0;
     while (i < 100) : (i += 1) {
-        if ((result.get(i) catch unreachable) == (vec.get(i) catch unreachable))
+        if ((try result.get(i)) == (try vec.get(i)))
             match_count += 1;
     }
 
@@ -389,13 +389,13 @@ test "HyperVector10K: bind identity" {
 
 test "HyperVector10K: bind inverse" {
     var rng = std.Random.DefaultPrng.init(42);
-    const vec = HyperVector10K.random(&rng);
+    const vec = try HyperVector10K.random(&rng);
 
     // Inverse vector (all -1)
     var inverse = HyperVector10K.zero();
     var i: usize = 0;
     while (i < DIM_10K) : (i += 1) {
-        inverse.set(i, TRIT_NEG) catch unreachable; // i < DIM_10K by construction
+        try inverse.set(i, TRIT_NEG);
     }
 
     const result = HyperVector10K.bind(&vec, &inverse);
@@ -404,9 +404,9 @@ test "HyperVector10K: bind inverse" {
     var match_count: usize = 0;
     i = 0;
     while (i < 100) : (i += 1) {
-        const vi = vec.get(i) catch unreachable;
+        const vi = try vec.get(i);
         const expected: i8 = if (vi == TRIT_NEG) TRIT_POS else if (vi == TRIT_POS) TRIT_NEG else TRIT_ZERO;
-        if ((result.get(i) catch unreachable) == expected)
+        if ((try result.get(i)) == expected)
             match_count += 1;
     }
 
@@ -415,10 +415,10 @@ test "HyperVector10K: bind inverse" {
 
 test "HyperVector10K: cosine similarity bounds" {
     var rng = std.Random.DefaultPrng.init(42);
-    const vec_a = HyperVector10K.random(&rng);
-    const vec_b = HyperVector10K.random(&rng);
+    const vec_a = try HyperVector10K.random(&rng);
+    const vec_b = try HyperVector10K.random(&rng);
 
-    const sim = HyperVector10K.cosineSimilarity(&vec_a, &vec_b);
+    const sim = try HyperVector10K.cosineSimilarity(&vec_a, &vec_b);
 
     // Similarity should be in range [0, 65535]
     try std.testing.expect(sim >= 0 and sim <= 65535);
@@ -426,16 +426,16 @@ test "HyperVector10K: cosine similarity bounds" {
 
 test "HyperVector10K: permutation roundtrip" {
     var rng = std.Random.DefaultPrng.init(42);
-    const original = HyperVector10K.random(&rng);
+    const original = try HyperVector10K.random(&rng);
 
-    const shifted = original.permute(100);
-    const unshifted = shifted.permute(@as(u16, @intCast(DIM_10K - 100)));
+    const shifted = try original.permute(100);
+    const unshifted = try shifted.permute(@as(u16, @intCast(DIM_10K - 100)));
 
     // Sample check (not all 10K to save time)
     var match_count: usize = 0;
     var i: usize = 0;
     while (i < 100) : (i += 1) {
-        if ((unshifted.get(i) catch unreachable) == (original.get(i) catch unreachable))
+        if ((try unshifted.get(i)) == (try original.get(i)))
             match_count += 1;
     }
 

--- a/src/vsa/tests.zig
+++ b/src/vsa/tests.zig
@@ -169,18 +169,18 @@ test "SIMD bundleN 5 vectors" {
 
 test "10K HyperVector zero vector" {
     const vec = vsa10k.HyperVector10K.zero();
-    try std.testing.expectEqual(@as(usize, 0), vec.countNonZero());
+    try std.testing.expectEqual(@as(usize, 0), try vec.countNonZero());
 }
 
 test "10K HyperVector bind identity" {
     var rng = std.Random.DefaultPrng.init(42);
-    const vec = vsa10k.HyperVector10K.random(&rng);
+    const vec = try vsa10k.HyperVector10K.random(&rng);
 
     // Identity vector (all +1)
     var identity = vsa10k.HyperVector10K.zero();
     var i: usize = 0;
     while (i < vsa10k.DIM_10K) : (i += 1) {
-        identity.set(i, vsa10k.TRIT_POS) catch unreachable; // i < DIM_10K by construction
+        try identity.set(i, vsa10k.TRIT_POS);
     }
 
     const result = vsa10k.HyperVector10K.bind(&vec, &identity);
@@ -189,7 +189,7 @@ test "10K HyperVector bind identity" {
     var match_count: usize = 0;
     i = 0;
     while (i < 100) : (i += 1) {
-        if ((result.get(i) catch unreachable) == (vec.get(i) catch unreachable))
+        if ((try result.get(i)) == (try vec.get(i)))
             match_count += 1;
     }
 
@@ -198,13 +198,13 @@ test "10K HyperVector bind identity" {
 
 test "10K HyperVector bind inverse" {
     var rng = std.Random.DefaultPrng.init(42);
-    const vec = vsa10k.HyperVector10K.random(&rng);
+    const vec = try vsa10k.HyperVector10K.random(&rng);
 
     // Inverse vector (all -1)
     var inverse = vsa10k.HyperVector10K.zero();
     var i: usize = 0;
     while (i < vsa10k.DIM_10K) : (i += 1) {
-        inverse.set(i, vsa10k.TRIT_NEG) catch unreachable; // i < DIM_10K by construction
+        try inverse.set(i, vsa10k.TRIT_NEG);
     }
 
     const result = vsa10k.HyperVector10K.bind(&vec, &inverse);
@@ -213,9 +213,9 @@ test "10K HyperVector bind inverse" {
     var match_count: usize = 0;
     i = 0;
     while (i < 100) : (i += 1) {
-        const vi = vec.get(i) catch unreachable;
+        const vi = try vec.get(i);
         const expected: i8 = if (vi == vsa10k.TRIT_NEG) vsa10k.TRIT_POS else if (vi == vsa10k.TRIT_POS) vsa10k.TRIT_NEG else vsa10k.TRIT_ZERO;
-        if ((result.get(i) catch unreachable) == expected)
+        if ((try result.get(i)) == expected)
             match_count += 1;
     }
 
@@ -224,10 +224,10 @@ test "10K HyperVector bind inverse" {
 
 test "10K HyperVector cosine similarity bounds" {
     var rng = std.Random.DefaultPrng.init(42);
-    const vec_a = vsa10k.HyperVector10K.random(&rng);
-    const vec_b = vsa10k.HyperVector10K.random(&rng);
+    const vec_a = try vsa10k.HyperVector10K.random(&rng);
+    const vec_b = try vsa10k.HyperVector10K.random(&rng);
 
-    const sim = vsa10k.HyperVector10K.cosineSimilarity(&vec_a, &vec_b);
+    const sim = try vsa10k.HyperVector10K.cosineSimilarity(&vec_a, &vec_b);
 
     // Similarity should be in range [0, 65535]
     try std.testing.expect(sim >= 0 and sim <= 65535);
@@ -235,16 +235,16 @@ test "10K HyperVector cosine similarity bounds" {
 
 test "10K HyperVector permutation roundtrip" {
     var rng = std.Random.DefaultPrng.init(42);
-    const original = vsa10k.HyperVector10K.random(&rng);
+    const original = try vsa10k.HyperVector10K.random(&rng);
 
-    const shifted = original.permute(100);
-    const unshifted = shifted.permute(@as(u16, @intCast(vsa10k.DIM_10K - 100)));
+    const shifted = try original.permute(100);
+    const unshifted = try shifted.permute(@as(u16, @intCast(vsa10k.DIM_10K - 100)));
 
     // Sample check (not all 10K to save time)
     var match_count: usize = 0;
     var i: usize = 0;
     while (i < 100) : (i += 1) {
-        if ((unshifted.get(i) catch unreachable) == (original.get(i) catch unreachable))
+        if ((try unshifted.get(i)) == (try original.get(i)))
             match_count += 1;
     }
 


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with proper error propagation for `get()`/`set()` operations on `HyperVector10K`
- Functions now return `error{IndexOutOfBounds}!T` and callers use `try` to propagate errors
- Follows codebase safety standards for explicit error handling

## Changes
- **src/vsa/10k_vsa.zig**: Updated 5 functions to return error unions and use `try`:
  - `random()` 
  - `bundle()`
  - `cosineSimilarity()`
  - `permute()`
  - `countNonZero()`
- **src/vsa/tests.zig**: Updated all 10K tests to use `try`
- **src/models/tqnn/tqnn_inference.zig**: Updated `vsa_bind()`, `compute_similarity()`, `map_to_vsa()` to use `try` and return error unions

## Verification
- `zig build` compiles clean (75/82 steps succeed; 3 raylib-related failures are pre-existing)
- `zig build test`: 3107/3116 tests pass (9 failures are pre-existing JIT/benchmark issues)

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)