### PR TITLE
fix(vsa): add hamming distance function to vsa.zig

### DIFF
--- a/src/vsa.zig
+++ b/src/vsa.zig
@@ -74,6 +74,23 @@ pub const getAgentMemory = agent.getAgentMemory;
 pub const getAutonomousAgent = agent.getAutonomousAgent;
 pub const getUnifiedSystem = agent.getUnifiedSystem;
 
+/// Hamming distance for slice-based ternary vectors.
+/// Counts positions where trits differ.
+pub fn hammingDistanceSlice(a: []const i8, b: []const i8) usize {
+    const len = @min(a.len, b.len);
+    var distance: usize = 0;
+
+    // Count differing positions in overlapping region
+    for (0..len) |i| {
+        if (a[i] != b[i]) distance += 1;
+    }
+
+    // Non-overlapping positions count as differences
+    distance += @abs(@as(isize, @intCast(a.len)) - @as(isize, @intCast(b.len)));
+
+    return distance;
+}
+
 test {
     _ = @import("vsa/tests.zig");
 }

--- a/src/vsa/tests.zig
+++ b/src/vsa/tests.zig
@@ -261,6 +261,45 @@ test "10K VSA benchmark quick" {
 }
 
 //==========================================================================
+// SLICE-BASED HAMMING DISTANCE TESTS (Issue #283)
+//==========================================================================
+
+test "hamming distance identical vectors" {
+    const a = [_]i8{ 1, -1, 0, 1, -1 };
+    const b = [_]i8{ 1, -1, 0, 1, -1 };
+    const dist = vsa.hammingDistanceSlice(&a, &b);
+    try std.testing.expectEqual(@as(usize, 0), dist);
+}
+
+test "hamming distance completely different" {
+    const a = [_]i8{ 1, 1, 1 };
+    const b = [_]i8{ -1, -1, -1 };
+    const dist = vsa.hammingDistanceSlice(&a, &b);
+    try std.testing.expectEqual(@as(usize, 3), dist);
+}
+
+test "hamming distance partial match" {
+    const a = [_]i8{ 1, -1, 0, 1, -1 };
+    const b = [_]i8{ 1, -1, 1, 1, -1 };
+    const dist = vsa.hammingDistanceSlice(&a, &b);
+    try std.testing.expectEqual(@as(usize, 1), dist); // Only position 2 differs
+}
+
+test "hamming distance different lengths" {
+    const a = [_]i8{ 1, -1, 0 };
+    const b = [_]i8{ 1, -1, 0, 1, -1 };
+    const dist = vsa.hammingDistanceSlice(&a, &b);
+    try std.testing.expectEqual(@as(usize, 2), dist); // 2 extra positions in b
+}
+
+test "hamming distance empty vectors" {
+    const a = [_]i8{};
+    const b = [_]i8{};
+    const dist = vsa.hammingDistanceSlice(&a, &b);
+    try std.testing.expectEqual(@as(usize, 0), dist);
+}
+
+//==========================================================================
 // TQNN TESTS (Week 2 Day 5)
 //==========================================================================
 


### PR DESCRIPTION
## Summary
- Add `hammingDistanceSlice(a: []const i8, b: []const i8) usize` function to `src/vsa.zig`
- Function counts positions where ternary trits differ
- Named `hammingDistanceSlice` to avoid conflict with existing `hammingDistance` that takes `*HybridBigInt` parameters

## Details
The function provides a lightweight alternative for fast approximate similarity when exact cosine is too expensive. It works directly on slices of ternary trits (`i8` values in {-1, 0, +1}).

**Implementation:**
- Counts differing positions in overlapping region
- Treats non-overlapping positions as differences
- Returns `usize` distance value

## Test Plan
- [x] Identical vectors → distance = 0
- [x] Completely different vectors → distance = length
- [x] Partial match (one position differs) → distance = 1
- [x] Different length vectors → includes extra positions
- [x] Empty vectors → distance = 0
- [x] `zig fmt src/` passes
- [x] `zig ast-check` passes for all modified files

Closes #283

🤖 Generated with [Claude Code](https://claude.com/claude-code)