### PR TITLE
fix(hslm): add STE gradient estimator to trainer

### DIFF
--- a/src/hslm/autograd.zig
+++ b/src/hslm/autograd.zig
@@ -737,3 +737,53 @@ test "backward linear gradient flow" {
     }
     try std.testing.expect(any_nonzero);
 }
+
+test "STE backward gradient passthrough" {
+    // Weights within [-1.5, 1.5] should have gradients pass through unchanged
+    const weights = [_]f32{ 0.5, -0.7, 1.2, -1.4, 0.0 };
+    var grads = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0 };
+    const original_grads = grads;
+
+    steBackward(&weights, &grads, 1.0);
+
+    // All weights are within range, gradients should be unchanged
+    for (0..weights.len) |i| {
+        try std.testing.expectApproxEqAbs(original_grads[i], grads[i], 1e-6);
+    }
+}
+
+test "STE backward gradient attenuation" {
+    // Weights outside [-1.5, 1.5] should have gradients attenuated
+    const weights = [_]f32{ 2.0, -2.0, 0.5, -1.6, 1.0 };
+    var grads = [_]f32{ 1.0, 2.0, 3.0, 4.0, 5.0 };
+
+    steBackward(&weights, &grads, 1.0);
+
+    // weights[0] = 2.0 > 1.5 → attenuated
+    try std.testing.expectApproxEqAbs(@as(f32, 0.1), grads[0], 1e-6);
+    // weights[1] = -2.0, |w| > 1.5 → attenuated
+    try std.testing.expectApproxEqAbs(@as(f32, 0.2), grads[1], 1e-6);
+    // weights[2] = 0.5 < 1.5 → unchanged
+    try std.testing.expectApproxEqAbs(@as(f32, 3.0), grads[2], 1e-6);
+    // weights[3] = -1.6, |w| > 1.5 → attenuated
+    try std.testing.expectApproxEqAbs(@as(f32, 0.4), grads[3], 1e-6);
+    // weights[4] = 1.0 < 1.5 → unchanged
+    try std.testing.expectApproxEqAbs(@as(f32, 5.0), grads[4], 1e-6);
+}
+
+test "STE backward with custom scale" {
+    // With scale=2.0, threshold becomes 3.0 (1.5 * 2.0)
+    const weights = [_]f32{ 2.5, -2.5, 3.5, -0.5 };
+    var grads = [_]f32{ 1.0, 2.0, 3.0, 4.0 };
+
+    steBackward(&weights, &grads, 2.0);
+
+    // |2.5/2.0| = 1.25 < 1.5 → unchanged
+    try std.testing.expectApproxEqAbs(@as(f32, 1.0), grads[0], 1e-6);
+    // |-2.5/2.0| = 1.25 < 1.5 → unchanged
+    try std.testing.expectApproxEqAbs(@as(f32, 2.0), grads[1], 1e-6);
+    // |3.5/2.0| = 1.75 > 1.5 → attenuated
+    try std.testing.expectApproxEqAbs(@as(f32, 0.3), grads[2], 1e-6);
+    // |-0.5/2.0| = 0.25 < 1.5 → unchanged
+    try std.testing.expectApproxEqAbs(@as(f32, 4.0), grads[3], 1e-6);
+}

--- a/src/hslm/trainer.zig
+++ b/src/hslm/trainer.zig
@@ -210,6 +210,11 @@ pub const FullTrainer = struct {
         autograd.clipGradNorm(self.model.grad_output_shadow, self.config.grad_clip);
         autograd.clipGradNorm(self.model.grad_output_bias, self.config.grad_clip);
 
+        // STE backward: gradient passthrough with saturation clipping
+        if (self.config.ste.mode != .none) {
+            autograd.steBackward(self.model.output_shadow, self.model.grad_output_shadow, 1.0);
+        }
+
         // AdamW step on output projection
         var offset: usize = 0;
         autograd.adamwStepSlice(&self.optimizer, self.model.output_shadow, self.model.grad_output_shadow, offset);
@@ -228,6 +233,12 @@ pub const FullTrainer = struct {
 
             autograd.clipGradNorm(block.tnn.grad_shadow_up, self.config.grad_clip);
             autograd.clipGradNorm(block.tnn.grad_shadow_down, self.config.grad_clip);
+
+            // STE backward for TNN weights
+            if (self.config.ste.mode != .none) {
+                autograd.steBackward(block.tnn.shadow_up, block.tnn.grad_shadow_up, 1.0);
+                autograd.steBackward(block.tnn.shadow_down, block.tnn.grad_shadow_down, 1.0);
+            }
 
             // AdamW step on TNN params
             autograd.adamwStepSlice(&self.optimizer, block.tnn.shadow_up, block.tnn.grad_shadow_up, offset);
@@ -250,6 +261,14 @@ pub const FullTrainer = struct {
             autograd.clipGradNorm(block.sacred_attn.grad_k, self.config.grad_clip);
             autograd.clipGradNorm(block.sacred_attn.grad_v, self.config.grad_clip);
             autograd.clipGradNorm(block.sacred_attn.grad_o, self.config.grad_clip);
+
+            // STE backward for attention weights
+            if (self.config.ste.mode != .none) {
+                autograd.steBackward(block.sacred_attn.shadow_q, block.sacred_attn.grad_q, 1.0);
+                autograd.steBackward(block.sacred_attn.shadow_k, block.sacred_attn.grad_k, 1.0);
+                autograd.steBackward(block.sacred_attn.shadow_v, block.sacred_attn.grad_v, 1.0);
+                autograd.steBackward(block.sacred_attn.shadow_o, block.sacred_attn.grad_o, 1.0);
+            }
 
             // AdamW step on attention params
             autograd.adamwStepSlice(&self.optimizer, block.sacred_attn.shadow_q, block.sacred_attn.grad_q, offset);


### PR DESCRIPTION
## Summary
- Add Straight-Through Estimator (STE) backward pass calls in the trainer's optimizer step
- STE allows gradients to flow through ternary quantization unchanged during backprop
- Attenuate gradients for weights far from quantization boundaries (saturated weights)

## Changes
- Call `steBackward()` for output projection weights after gradient clipping
- Call `steBackward()` for TNN weights (up/down projections)
- Call `steBackward()` for attention weights (Q, K, V, O)
- Add 3 tests verifying STE gradient passthrough behavior

## Test Plan
- [x] `zig test src/hslm/trainer.zig` — all 90 tests pass
- [x] New STE backward tests verify gradient passthrough for weights in range
- [x] New tests verify gradient attenuation for saturated weights

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)