### PR TITLE
fix(tri): catch unreachable → proper error handling in job_artifact.zig hex encoding (#290)

### DIFF
--- a/src/tri/job_artifact.zig
+++ b/src/tri/job_artifact.zig
@@ -297,7 +297,10 @@ pub const ArtifactCollector = struct {
         // Convert to hex string
         const hex = try self.allocator.alloc(u8, 64);
         for (digest, 0..) |byte, i| {
-            _ = std.fmt.bufPrint(hex[2 * i ..], "{x:0>2}", .{byte}) catch unreachable;
+            _ = std.fmt.bufPrint(hex[2 * i ..], "{x:0>2}", .{byte}) catch |e| {
+                std.log.warn("hex encoding failed: {}", .{e});
+                return error.HexEncodingFailed;
+            };
         }
 
         return hex;


### PR DESCRIPTION
## Summary
- Replace `catch unreachable` with proper error handling in `src/tri/job_artifact.zig`
- Log warning and return `error.HexEncodingFailed` when hex encoding fails

## Test plan
- [x] `zig ast-check src/tri/job_artifact.zig` passes
- [ ] `zig build` (blocked by pre-existing errors in other files)

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)