### PR TITLE
feat(simd): AVX2 32-wide vectors in simd_ops.zig

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -4,8 +4,26 @@ const std = @import("std");
 // For Zig 0.13.x use build.zig
 
 pub fn build(b: *std.Build) void {
-    const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
+
+    // AVX2 mode: Enable x86_64_v3 features (AVX2, FMA, BMI1/2, F16C) for 32-wide SIMD
+    // Usage: zig build -Doptimize=ReleaseFast -Davx2=true
+    // This enables 32-wide vector operations in src/hslm/simd_ops.zig
+    const enable_avx2 = b.option(bool, "avx2", "Enable AVX2 256-bit SIMD for HSLM (x86_64_v3 baseline)") orelse false;
+
+    // Resolve target: use x86_64_v3 (AVX2) if -Davx2=true, otherwise use standard options
+    const target: std.Build.ResolvedTarget = blk: {
+        if (enable_avx2) {
+            const avx2_query: std.Target.Query = .{
+                .cpu_arch = .x86_64,
+                .os_tag = .linux,
+                .cpu_model = .{ .explicit = &std.Target.x86.cpu.x86_64_v3 },
+            };
+            break :blk b.resolveTargetQuery(avx2_query);
+        } else {
+            break :blk b.standardTargetOptions(.{});
+        }
+    };
 
     // CI mode: skip targets requiring system libraries (raylib, etc.)
     const ci_mode = b.option(bool, "ci", "CI mode: skip GUI and system-library targets") orelse false;
@@ -1557,6 +1575,27 @@ pub fn build(b: *std.Build) void {
     const hslm_bench_step = b.step("hslm-bench", "Run HSLM inference platform benchmark");
     hslm_bench_step.dependOn(&run_hslm_bench.step);
 
+    // HSLM AVX2 Benchmark — 32-wide SIMD for x86_64 with AVX2
+    // Usage: zig build hslm-bench-avx2 -Doptimize=ReleaseFast
+    const hslm_avx2_query: std.Target.Query = .{
+        .cpu_arch = .x86_64,
+        .os_tag = .linux,
+        .cpu_model = .{ .explicit = &std.Target.x86.cpu.x86_64_v3 },
+    };
+    const hslm_avx2_target = b.resolveTargetQuery(hslm_avx2_query);
+    const hslm_bench_avx2 = b.addExecutable(.{
+        .name = "hslm-bench-avx2",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/hslm/hslm_benchmark.zig"),
+            .target = hslm_avx2_target,
+            .optimize = .ReleaseFast,
+        }),
+    });
+    b.installArtifact(hslm_bench_avx2);
+    const run_hslm_bench_avx2 = b.addRunArtifact(hslm_bench_avx2);
+    const hslm_bench_avx2_step = b.step("hslm-bench-avx2", "Run HSLM benchmark with AVX2 32-wide SIMD (x86_64_v3)");
+    hslm_bench_avx2_step.dependOn(&run_hslm_bench_avx2.step);
+
     // ═══════════════════════════════════════════════════════════════════════════
     // BPE Tokenizer Trainer
     // ═══════════════════════════════════════════════════════════════════════════
@@ -1964,166 +2003,166 @@ pub fn build(b: *std.Build) void {
     // Chat/Code/Vision/Voice/Tools/Autonomous all in cosmic canvas
     // Skipped in CI mode (-Dci=true) since raylib is not available
     if (!ci_mode) {
-    const trinity_canvas = b.addExecutable(.{
-        .name = "trinity-canvas",
-        .root_module = b.createModule(.{
-            .root_source_file = b.path("src/vsa/photon_trinity_canvas.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "igla_chat", .module = vibeec_chat },
-                .{ .name = "igla_fluent_chat", .module = vibeec_fluent_chat },
-                .{ .name = "igla_hybrid_chat", .module = vibeec_hybrid_chat },
-                .{ .name = "golden_chain", .module = golden_chain_mod },
-                .{ .name = "tvc_corpus", .module = tvc_corpus_mod },
-                .{ .name = "auto_shard", .module = b.createModule(.{
-                    .root_source_file = b.path("src/trinity_node/auto_shard.zig"),
-                    .target = target,
-                    .optimize = optimize,
-                }) },
-            },
-        }),
-    });
-    trinity_canvas.linkSystemLibrary("raylib");
-    // v8.4: Add raygui include path and C implementation
-    trinity_canvas.addIncludePath(b.path("external/raygui/src"));
-    trinity_canvas.addCSourceFile(.{ .file = b.path("src/vsa/raygui_impl.c") });
-    // TEMP: Disable install until raygui.h is available
-    // b.installArtifact(trinity_canvas);
+        const trinity_canvas = b.addExecutable(.{
+            .name = "trinity-canvas",
+            .root_module = b.createModule(.{
+                .root_source_file = b.path("src/vsa/photon_trinity_canvas.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "igla_chat", .module = vibeec_chat },
+                    .{ .name = "igla_fluent_chat", .module = vibeec_fluent_chat },
+                    .{ .name = "igla_hybrid_chat", .module = vibeec_hybrid_chat },
+                    .{ .name = "golden_chain", .module = golden_chain_mod },
+                    .{ .name = "tvc_corpus", .module = tvc_corpus_mod },
+                    .{ .name = "auto_shard", .module = b.createModule(.{
+                        .root_source_file = b.path("src/trinity_node/auto_shard.zig"),
+                        .target = target,
+                        .optimize = optimize,
+                    }) },
+                },
+            }),
+        });
+        trinity_canvas.linkSystemLibrary("raylib");
+        // v8.4: Add raygui include path and C implementation
+        trinity_canvas.addIncludePath(b.path("external/raygui/src"));
+        trinity_canvas.addCSourceFile(.{ .file = b.path("src/vsa/raygui_impl.c") });
+        // TEMP: Disable install until raygui.h is available
+        // b.installArtifact(trinity_canvas);
 
-    const run_trinity_canvas = b.addRunArtifact(trinity_canvas);
-    if (b.args) |args| {
-        run_trinity_canvas.addArgs(args);
-    }
-    const trinity_canvas_step = b.step("trinity-canvas", "Run Trinity Cosmic Canvas (v1.9 Emergent Wave)");
-    trinity_canvas_step.dependOn(&run_trinity_canvas.step);
+        const run_trinity_canvas = b.addRunArtifact(trinity_canvas);
+        if (b.args) |args| {
+            run_trinity_canvas.addArgs(args);
+        }
+        const trinity_canvas_step = b.step("trinity-canvas", "Run Trinity Cosmic Canvas (v1.9 Emergent Wave)");
+        trinity_canvas_step.dependOn(&run_trinity_canvas.step);
 
-    // ═══════════════════════════════════════════════════════════════════════════
-    // Trinity Canvas WASM — compiles the same canvas for browsers via Emscripten
-    // Build: zig build trinity-canvas-wasm -Dtarget=wasm32-emscripten
-    // Output: zig-out/web/ (trinity-canvas.html, .js, .wasm, .data)
-    // ═══════════════════════════════════════════════════════════════════════════
-    {
-        // WASM stub modules (replace system-dependent chat/network/fs)
-        const wasm_igla_chat = b.createModule(.{
-            .root_source_file = b.path("src/wasm_stubs/igla_chat_stub.zig"),
-            .target = target,
-            .optimize = optimize,
-        });
-        const wasm_fluent_chat = b.createModule(.{
-            .root_source_file = b.path("src/wasm_stubs/igla_fluent_chat_stub.zig"),
-            .target = target,
-            .optimize = optimize,
-        });
-        const wasm_tvc_corpus = b.createModule(.{
-            .root_source_file = b.path("src/wasm_stubs/tvc_corpus_stub.zig"),
-            .target = target,
-            .optimize = optimize,
-        });
-        const wasm_auto_shard = b.createModule(.{
-            .root_source_file = b.path("src/wasm_stubs/auto_shard_stub.zig"),
-            .target = target,
-            .optimize = optimize,
-        });
-        const wasm_igla_kg = b.createModule(.{
-            .root_source_file = b.path("src/wasm_stubs/igla_knowledge_graph_stub.zig"),
-            .target = target,
-            .optimize = optimize,
-        });
-        const wasm_hybrid_chat = b.createModule(.{
-            .root_source_file = b.path("src/wasm_stubs/igla_hybrid_chat_stub.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "igla_chat", .module = wasm_igla_chat },
-                .{ .name = "tvc_corpus", .module = wasm_tvc_corpus },
-                .{ .name = "igla_kg", .module = wasm_igla_kg },
-                .{ .name = "triples_parser", .module = triples_parser_mod },
-            },
-        });
-        const wasm_golden_chain = b.createModule(.{
-            .root_source_file = b.path("src/wasm_stubs/golden_chain_stub.zig"),
-            .target = target,
-            .optimize = optimize,
-            .imports = &.{
-                .{ .name = "igla_hybrid_chat", .module = wasm_hybrid_chat },
-            },
-        });
-
-        const wasm_root = b.createModule(.{
-            // ONE SOURCE OF TRUTH: same file as native build, with is_emscripten gates
-            .root_source_file = b.path("src/vsa/photon_trinity_canvas.zig"),
-            .target = target,
-            .optimize = optimize,
-            .link_libc = true,
-            .imports = &.{
-                .{ .name = "igla_chat", .module = wasm_igla_chat },
-                .{ .name = "igla_fluent_chat", .module = wasm_fluent_chat },
-                .{ .name = "igla_hybrid_chat", .module = wasm_hybrid_chat },
-                .{ .name = "golden_chain", .module = wasm_golden_chain },
-                .{ .name = "tvc_corpus", .module = wasm_tvc_corpus },
-                .{ .name = "auto_shard", .module = wasm_auto_shard },
-            },
-        });
-
-        const wasm_step = b.step("trinity-canvas-wasm", "Build Trinity Canvas for Web (WASM via Emscripten)");
-
-        if (target.query.os_tag == .emscripten) {
-            // ── Emscripten WASM build (raylib-zig emsdk helpers) ──
-            const raylib_zig = @import("raylib");
-
-            // Get raylib C library compiled for emscripten
-            const raylib_dep = b.dependency("raylib", .{
+        // ═══════════════════════════════════════════════════════════════════════════
+        // Trinity Canvas WASM — compiles the same canvas for browsers via Emscripten
+        // Build: zig build trinity-canvas-wasm -Dtarget=wasm32-emscripten
+        // Output: zig-out/web/ (trinity-canvas.html, .js, .wasm, .data)
+        // ═══════════════════════════════════════════════════════════════════════════
+        {
+            // WASM stub modules (replace system-dependent chat/network/fs)
+            const wasm_igla_chat = b.createModule(.{
+                .root_source_file = b.path("src/wasm_stubs/igla_chat_stub.zig"),
                 .target = target,
                 .optimize = optimize,
             });
-            const raylib_artifact = raylib_dep.artifact("raylib");
-
-            // Link raylib C library and add its include path for @cImport("raylib.h")
-            wasm_root.linkLibrary(raylib_artifact);
-            wasm_root.addIncludePath(raylib_dep.path("src"));
-
-            const wasm = b.addLibrary(.{
-                .name = "trinity-canvas",
-                .root_module = wasm_root,
-                .linkage = .static,
-            });
-
-            const install_dir: std.Build.InstallDir = .{ .custom = "web" };
-            const emcc_flags = raylib_zig.emsdk.emccDefaultFlags(b.allocator, .{
-                .optimize = optimize,
-                .asyncify = true,
-            });
-            var emcc_settings = raylib_zig.emsdk.emccDefaultSettings(b.allocator, .{
+            const wasm_fluent_chat = b.createModule(.{
+                .root_source_file = b.path("src/wasm_stubs/igla_fluent_chat_stub.zig"),
+                .target = target,
                 .optimize = optimize,
             });
-            // Trinity Canvas needs ~256MB for grid + fonts + particles
-            emcc_settings.put("ALLOW_MEMORY_GROWTH", "1") catch unreachable;
-            emcc_settings.put("INITIAL_MEMORY", "268435456") catch unreachable; // 256MB
-
-            const emcc_link = raylib_zig.emsdk.emccStep(b, raylib_artifact, wasm, .{
+            const wasm_tvc_corpus = b.createModule(.{
+                .root_source_file = b.path("src/wasm_stubs/tvc_corpus_stub.zig"),
+                .target = target,
                 .optimize = optimize,
-                .flags = emcc_flags,
-                .settings = emcc_settings,
-                .shell_file_path = b.path("src/wasm_stubs/shell.html"),
-                .install_dir = install_dir,
-                .embed_paths = &.{.{ .src_path = b.pathFromRoot("assets/fonts"), .virtual_path = "assets/fonts" }},
+            });
+            const wasm_auto_shard = b.createModule(.{
+                .root_source_file = b.path("src/wasm_stubs/auto_shard_stub.zig"),
+                .target = target,
+                .optimize = optimize,
+            });
+            const wasm_igla_kg = b.createModule(.{
+                .root_source_file = b.path("src/wasm_stubs/igla_knowledge_graph_stub.zig"),
+                .target = target,
+                .optimize = optimize,
+            });
+            const wasm_hybrid_chat = b.createModule(.{
+                .root_source_file = b.path("src/wasm_stubs/igla_hybrid_chat_stub.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "igla_chat", .module = wasm_igla_chat },
+                    .{ .name = "tvc_corpus", .module = wasm_tvc_corpus },
+                    .{ .name = "igla_kg", .module = wasm_igla_kg },
+                    .{ .name = "triples_parser", .module = triples_parser_mod },
+                },
+            });
+            const wasm_golden_chain = b.createModule(.{
+                .root_source_file = b.path("src/wasm_stubs/golden_chain_stub.zig"),
+                .target = target,
+                .optimize = optimize,
+                .imports = &.{
+                    .{ .name = "igla_hybrid_chat", .module = wasm_hybrid_chat },
+                },
             });
 
-            wasm_step.dependOn(emcc_link);
-        } else {
-            // ── Native build (for compilation check without emsdk) ──
-            const wasm_canvas = b.addExecutable(.{
-                .name = "trinity-canvas-wasm-check",
-                .root_module = wasm_root,
+            const wasm_root = b.createModule(.{
+                // ONE SOURCE OF TRUTH: same file as native build, with is_emscripten gates
+                .root_source_file = b.path("src/vsa/photon_trinity_canvas.zig"),
+                .target = target,
+                .optimize = optimize,
+                .link_libc = true,
+                .imports = &.{
+                    .{ .name = "igla_chat", .module = wasm_igla_chat },
+                    .{ .name = "igla_fluent_chat", .module = wasm_fluent_chat },
+                    .{ .name = "igla_hybrid_chat", .module = wasm_hybrid_chat },
+                    .{ .name = "golden_chain", .module = wasm_golden_chain },
+                    .{ .name = "tvc_corpus", .module = wasm_tvc_corpus },
+                    .{ .name = "auto_shard", .module = wasm_auto_shard },
+                },
             });
-            wasm_canvas.linkSystemLibrary("raylib");
-            wasm_canvas.linkLibC();
-            // TEMP: Disable install until raygui.h is available
-            // b.installArtifact(wasm_canvas);
-            wasm_step.dependOn(b.getInstallStep());
+
+            const wasm_step = b.step("trinity-canvas-wasm", "Build Trinity Canvas for Web (WASM via Emscripten)");
+
+            if (target.query.os_tag == .emscripten) {
+                // ── Emscripten WASM build (raylib-zig emsdk helpers) ──
+                const raylib_zig = @import("raylib");
+
+                // Get raylib C library compiled for emscripten
+                const raylib_dep = b.dependency("raylib", .{
+                    .target = target,
+                    .optimize = optimize,
+                });
+                const raylib_artifact = raylib_dep.artifact("raylib");
+
+                // Link raylib C library and add its include path for @cImport("raylib.h")
+                wasm_root.linkLibrary(raylib_artifact);
+                wasm_root.addIncludePath(raylib_dep.path("src"));
+
+                const wasm = b.addLibrary(.{
+                    .name = "trinity-canvas",
+                    .root_module = wasm_root,
+                    .linkage = .static,
+                });
+
+                const install_dir: std.Build.InstallDir = .{ .custom = "web" };
+                const emcc_flags = raylib_zig.emsdk.emccDefaultFlags(b.allocator, .{
+                    .optimize = optimize,
+                    .asyncify = true,
+                });
+                var emcc_settings = raylib_zig.emsdk.emccDefaultSettings(b.allocator, .{
+                    .optimize = optimize,
+                });
+                // Trinity Canvas needs ~256MB for grid + fonts + particles
+                emcc_settings.put("ALLOW_MEMORY_GROWTH", "1") catch unreachable;
+                emcc_settings.put("INITIAL_MEMORY", "268435456") catch unreachable; // 256MB
+
+                const emcc_link = raylib_zig.emsdk.emccStep(b, raylib_artifact, wasm, .{
+                    .optimize = optimize,
+                    .flags = emcc_flags,
+                    .settings = emcc_settings,
+                    .shell_file_path = b.path("src/wasm_stubs/shell.html"),
+                    .install_dir = install_dir,
+                    .embed_paths = &.{.{ .src_path = b.pathFromRoot("assets/fonts"), .virtual_path = "assets/fonts" }},
+                });
+
+                wasm_step.dependOn(emcc_link);
+            } else {
+                // ── Native build (for compilation check without emsdk) ──
+                const wasm_canvas = b.addExecutable(.{
+                    .name = "trinity-canvas-wasm-check",
+                    .root_module = wasm_root,
+                });
+                wasm_canvas.linkSystemLibrary("raylib");
+                wasm_canvas.linkLibC();
+                // TEMP: Disable install until raygui.h is available
+                // b.installArtifact(wasm_canvas);
+                wasm_step.dependOn(b.getInstallStep());
+            }
         }
-    }
     } // end if (!ci_mode) — raylib canvas targets
 
     // Photon Terminal v1.0 - TERNARY EMERGENT TUI
@@ -2283,7 +2322,6 @@ pub fn build(b: *std.Build) void {
     // P1.5: Registry Export — Generate registry.json from CommandDef
     // ═══════════════════════════════════════════════════════════════════════════════
 
-
     const registry_export_exe = b.addExecutable(.{
         .name = "export-registry",
         .root_module = b.createModule(.{
@@ -2323,5 +2361,4 @@ pub fn build(b: *std.Build) void {
     if (b.args) |args| run_tri_api.addArgs(args);
     const tri_api_step = b.step("tri-api", "Run TRI-API — Direct Anthropic API Agent");
     tri_api_step.dependOn(&run_tri_api.step);
-
 }

--- a/src/hslm/simd_ops.zig
+++ b/src/hslm/simd_ops.zig
@@ -1,22 +1,37 @@
 // HSLM — SIMD Ternary Operations
-// Vectorized ternary matmul using @Vector(8, f32) → ARM NEON fmla
+// Vectorized ternary matmul using @Vector(N, f32):
+//   - ARM NEON (128-bit):  8-wide fmla
+//   - x86 AVX2 (256-bit): 32-wide vfmadd
 // Replaces scalar if/else branch pattern with @floatFromInt multiply
-// Key insight: {-1,0,+1} * val = {-val, 0, val} — branchless via fmla
+// Key insight: {-1,0,+1} * val = {-val, 0, val} — branchless via fmla/vfmadd
 
 const std = @import("std");
+const builtin = @import("builtin");
 
-const VEC_SIZE = 8;
-const Vec8 = @Vector(VEC_SIZE, f32);
-const Vec8i = @Vector(VEC_SIZE, i8);
-const Vec8i16 = @Vector(VEC_SIZE, i16);
-const zero_vec: Vec8 = @splat(0.0);
+// AVX2 detection: x86_64 with AVX2 feature enabled
+// x86_64_v3 baseline guarantees AVX2, FMA, BMI1/2, F16C
+// At compile time, check if target CPU supports AVX2
+const has_avx2 = builtin.cpu.arch == .x86_64 and
+    std.Target.x86.featureSetHas(builtin.cpu.features, .avx2);
+
+// Select vector width based on target capabilities:
+// - AVX2 (256-bit): 32 x i8 = 256 bits → 4x throughput vs NEON
+// - NEON/SSE2 (128-bit): 8 x i8 = 64 bits → baseline
+const VEC_SIZE: usize = if (has_avx2) 32 else 8;
+
+const Vec = @Vector(VEC_SIZE, f32);
+const Veci = @Vector(VEC_SIZE, i8);
+// For AVX2 (32-wide), use i32 intermediate to prevent overflow during widening
+// For NEON (8-wide), i16 is sufficient
+const VeciWide = if (has_avx2) @Vector(VEC_SIZE, i32) else @Vector(VEC_SIZE, i16);
+const zero_vec: Vec = @splat(0.0);
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // FORWARD: y[j] = Sum_i W[i*out_dim+j] * x[i]
 // ═══════════════════════════════════════════════════════════════════════════════
 
 /// SIMD ternary matrix-vector multiply (forward).
-/// Scatter pattern: outer=input i (broadcast), inner=output j (SIMD 8-wide).
+/// Scatter pattern: outer=input i (broadcast), inner=output j (SIMD N-wide).
 /// Weight layout: row-major W[i * out_dim + j], contiguous in j for fixed i.
 pub fn ternaryMatvecSimd(
     input: []const f32,
@@ -31,18 +46,18 @@ pub fn ternaryMatvecSimd(
     for (0..in_dim) |i| {
         const val = input[i];
         if (val == 0.0) continue; // Skip zero inputs (common in ReLU'd activations)
-        const val_vec: Vec8 = @splat(val);
+        const val_vec: Vec = @splat(val);
         const w_base = i * out_dim;
 
         var j: usize = 0;
         while (j + VEC_SIZE <= out_dim) : (j += VEC_SIZE) {
-            const w_i8: Vec8i = weights[w_base + j ..][0..VEC_SIZE].*;
-            const w_f32: Vec8 = @floatFromInt(@as(Vec8i16, w_i8));
-            var out_vec: Vec8 = output[j..][0..VEC_SIZE].*;
-            out_vec += w_f32 * val_vec; // fmla on ARM NEON
+            const w_i8: Veci = weights[w_base + j ..][0..VEC_SIZE].*;
+            const w_f32: Vec = @floatFromInt(@as(VeciWide, w_i8));
+            var out_vec: Vec = output[j..][0..VEC_SIZE].*;
+            out_vec += w_f32 * val_vec; // fmla on ARM NEON, vfmadd on AVX2
             output[j..][0..VEC_SIZE].* = out_vec;
         }
-        // Scalar remainder (243%8=3, 729%8=1)
+        // Scalar remainder (243%32=27, 729%32=25 on AVX2)
         while (j < out_dim) : (j += 1) {
             const w = weights[w_base + j];
             if (w == 1) {
@@ -60,7 +75,7 @@ pub fn ternaryMatvecSimd(
 
 /// SIMD ternary vector-matrix multiply (backward input gradient).
 /// Gather pattern: for each row i, dot product of weight row with grad_output.
-/// Both W[i*out+j..j+8] and grad_output[j..j+8] are contiguous.
+/// Both W[i*out+j..j+N] and grad_output[j..j+N] are contiguous.
 pub fn ternaryVecmatSimd(
     grad_output: []const f32,
     weights: []const i8,
@@ -70,12 +85,12 @@ pub fn ternaryVecmatSimd(
 ) void {
     for (0..in_dim) |i| {
         const w_base = i * out_dim;
-        var acc: Vec8 = zero_vec;
+        var acc: Vec = zero_vec;
         var j: usize = 0;
         while (j + VEC_SIZE <= out_dim) : (j += VEC_SIZE) {
-            const w_i8: Vec8i = weights[w_base + j ..][0..VEC_SIZE].*;
-            const w_f32: Vec8 = @floatFromInt(@as(Vec8i16, w_i8));
-            const g: Vec8 = grad_output[j..][0..VEC_SIZE].*;
+            const w_i8: Veci = weights[w_base + j ..][0..VEC_SIZE].*;
+            const w_f32: Vec = @floatFromInt(@as(VeciWide, w_i8));
+            const g: Vec = grad_output[j..][0..VEC_SIZE].*;
             acc += w_f32 * g;
         }
         var sum: f32 = @reduce(.Add, acc);
@@ -102,12 +117,12 @@ pub fn ternaryVecmatSimdAccum(
 ) void {
     for (0..in_dim) |i| {
         const w_base = i * out_dim;
-        var acc: Vec8 = zero_vec;
+        var acc: Vec = zero_vec;
         var j: usize = 0;
         while (j + VEC_SIZE <= out_dim) : (j += VEC_SIZE) {
-            const w_i8: Vec8i = weights[w_base + j ..][0..VEC_SIZE].*;
-            const w_f32: Vec8 = @floatFromInt(@as(Vec8i16, w_i8));
-            const g: Vec8 = grad_output[j..][0..VEC_SIZE].*;
+            const w_i8: Veci = weights[w_base + j ..][0..VEC_SIZE].*;
+            const w_f32: Vec = @floatFromInt(@as(VeciWide, w_i8));
+            const g: Vec = grad_output[j..][0..VEC_SIZE].*;
             acc += w_f32 * g;
         }
         var sum: f32 = @reduce(.Add, acc);
@@ -139,13 +154,13 @@ pub fn outerProductAccumSimd(
     for (0..in_dim) |i| {
         const cached_val = cached_input[i];
         if (cached_val == 0.0) continue; // Skip zero cached values
-        const val_vec: Vec8 = @splat(cached_val);
+        const val_vec: Vec = @splat(cached_val);
         const gw_base = i * out_dim;
 
         var j: usize = 0;
         while (j + VEC_SIZE <= out_dim) : (j += VEC_SIZE) {
-            const g: Vec8 = grad_output[j..][0..VEC_SIZE].*;
-            var gw: Vec8 = grad_weights[gw_base + j ..][0..VEC_SIZE].*;
+            const g: Vec = grad_output[j..][0..VEC_SIZE].*;
+            var gw: Vec = grad_weights[gw_base + j ..][0..VEC_SIZE].*;
             gw += g * val_vec;
             grad_weights[gw_base + j ..][0..VEC_SIZE].* = gw;
         }
@@ -218,10 +233,31 @@ fn outerProductAccumScalar(
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// RUNTIME INFO
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Returns the SIMD vector width (8 for NEON, 32 for AVX2).
+pub fn getVectorWidth() usize {
+    return VEC_SIZE;
+}
+
+/// Returns true if AVX2 256-bit SIMD is enabled at compile time.
+pub fn hasAvx2() bool {
+    return has_avx2;
+}
+
+/// Returns SIMD target name for logging/benchmarking.
+pub fn getSimdTarget() []const u8 {
+    return if (has_avx2) "AVX2-256bit" else "NEON/SSE-128bit";
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // TESTS
 // ═══════════════════════════════════════════════════════════════════════════════
 
-const TOLERANCE: f32 = 1e-5;
+// Tolerance for SIMD vs scalar comparison.
+// 32-wide AVX2 accumulates more floating-point rounding error than 8-wide NEON.
+const TOLERANCE: f32 = 1e-4;
 
 fn approxEqual(a: f32, b: f32) bool {
     return @abs(a - b) < TOLERANCE;
@@ -372,5 +408,40 @@ test "simd edge cases — all zero weights" {
 
     for (0..dim) |j| {
         try std.testing.expect(output[j] == 0.0);
+    }
+}
+
+test "simd vector width detection" {
+    // Vector width should be 8 (NEON) or 32 (AVX2)
+    try std.testing.expect(VEC_SIZE == 8 or VEC_SIZE == 32);
+
+    // On x86_64 with AVX2, should be 32-wide
+    // On ARM or x86_64 without AVX2, should be 8-wide
+    if (has_avx2) {
+        try std.testing.expect(VEC_SIZE == 32);
+        try std.testing.expectEqual(@as(usize, 32), getVectorWidth());
+    } else {
+        try std.testing.expect(VEC_SIZE == 8);
+        try std.testing.expectEqual(@as(usize, 8), getVectorWidth());
+    }
+}
+
+test "simd forward with 32-aligned dimension" {
+    // Test with dimension that's evenly divisible by 32 (AVX2 case)
+    const in_dim = 64;
+    const out_dim = 64;
+    var input: [in_dim]f32 = undefined;
+    var weights: [in_dim * out_dim]i8 = undefined;
+    var output_simd: [out_dim]f32 = undefined;
+    var output_scalar: [out_dim]f32 = undefined;
+
+    fillRandom(&input, 0xA100, 1.0);
+    fillTernaryWeights(&weights, 0xB100);
+
+    ternaryMatvecSimd(&input, &weights, &output_simd, in_dim, out_dim);
+    ternaryMatvecScalar(&input, &weights, &output_scalar, in_dim, out_dim);
+
+    for (0..out_dim) |j| {
+        try std.testing.expect(approxEqual(output_simd[j], output_scalar[j]));
     }
 }


### PR DESCRIPTION
## Summary

Implements AVX2 32-wide SIMD vectors for HSLM ternary operations, targeting Railway Intel Xeon CPUs that support AVX2 (256-bit).

## Changes

### `src/hslm/simd_ops.zig`
- Added compile-time AVX2 detection via `std.Target.x86.featureSetHas`
- Changed vector width from 8 (NEON 128-bit) to 32 (AVX2 256-bit) when AVX2 is available
- Updated type aliases: `Vec8` → `Vec`, `Vec8i` → `Veci`, `Vec8i16` → `VeciWide`
- For AVX2, uses `i32` intermediate type to prevent overflow in 32-wide operations
- Added runtime info functions: `getVectorWidth()`, `hasAvx2()`, `getSimdTarget()`
- Added tests for vector width detection and 32-aligned dimensions

### `build.zig`
- Added `-Davx2` option for x86_64_v3 baseline (AVX2, FMA, BMI1/2, F16C)
- Added `hslm-bench-avx2` step: `zig build hslm-bench-avx2 -Doptimize=ReleaseFast`

## Verification

- All 9 simd_ops tests pass ✅
- All 113 HSLM tests pass ✅
- AVX2 benchmark builds and runs successfully ✅

## Usage

```bash
# Build with AVX2 support
zig build -Doptimize=ReleaseFast -Davx2=true

# Run AVX2 benchmark
zig build hslm-bench-avx2 -Doptimize=ReleaseFast
```

## Expected Speedup

- 4x wider vectors (32 vs 8) = 2-3x matmul throughput improvement
- Railway Intel Xeon supports AVX2 (256-bit)

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)