### PR TITLE
feat(tri-lang): content-addressed function storage (Unison-style)

### DIFF
--- a/src/tri_lang/content_hash.zig
+++ b/src/tri_lang/content_hash.zig
@@ -1,0 +1,180 @@
+const std = @import("std");
+const crypto = std.crypto;
+
+pub const ContentHash = [32]u8;
+
+pub const FunctionAst = struct {
+    name: []const u8,
+    params: []const Param,
+    return_type: []const u8,
+    body_hash: ContentHash,
+};
+
+pub const Param = struct {
+    name: []const u8,
+    type_expr: []const u8,
+};
+
+pub fn hashFunction(allocator: std.mem.Allocator, func: FunctionAst) !ContentHash {
+    var buf = std.ArrayList(u8).init(allocator);
+    defer buf.deinit();
+
+    try buf.appendSlice("fn:");
+    try buf.appendSlice(func.return_type);
+    try buf.appendSlice("(");
+
+    for (func.params, 0..) |p, i| {
+        if (i > 0) try buf.appendSlice(",");
+        try buf.appendSlice("_:");
+        try buf.appendSlice(p.type_expr);
+    }
+
+    try buf.appendSlice("):");
+    try buf.appendSlice(&func.body_hash);
+
+    var result: ContentHash = undefined;
+    crypto.hash.sha2.Sha256.hash(buf.items, &result, .{});
+    return result;
+}
+
+pub fn normalizeParams(params: []const Param, allocator: std.mem.Allocator) ![]NormalizedParam {
+    var result = try std.ArrayList(NormalizedParam).initCapacity(allocator, params.len);
+    for (params, 0..) |p, i| {
+        result.appendAssumeCapacity(.{
+            .canonical_name = try std.fmt.allocPrint(allocator, "_p{d}", .{i}),
+            .type_expr = p.type_expr,
+        });
+    }
+    return result.toOwnedSlice();
+}
+
+pub const NormalizedParam = struct {
+    canonical_name: []const u8,
+    type_expr: []const u8,
+};
+
+pub fn alphaEquivalent(a: FunctionAst, b: FunctionAst) bool {
+    if (a.params.len != b.params.len) return false;
+    if (!std.mem.eql(u8, a.return_type, b.return_type)) return false;
+
+    for (a.params, b.params) |pa, pb| {
+        if (!std.mem.eql(u8, pa.type_expr, pb.type_expr)) return false;
+    }
+
+    return std.mem.eql(u8, &a.body_hash, &b.body_hash);
+}
+
+pub fn hashToString(hash: ContentHash) [64]u8 {
+    var buf: [64]u8 = undefined;
+    _ = std.fmt.bufPrint(&buf, "{s}", .{std.fmt.fmtSliceHexLower(&hash)}) catch unreachable;
+    return buf;
+}
+
+test "hash function produces consistent results" {
+    const allocator = std.testing.allocator;
+    const body_hash: ContentHash = [_]u8{0xAA} ** 32;
+
+    const func = FunctionAst{
+        .name = "add",
+        .params = &.{
+            .{ .name = "x", .type_expr = "i32" },
+            .{ .name = "y", .type_expr = "i32" },
+        },
+        .return_type = "i32",
+        .body_hash = body_hash,
+    };
+
+    const h1 = try hashFunction(allocator, func);
+    const h2 = try hashFunction(allocator, func);
+    try std.testing.expectEqualSlices(u8, &h1, &h2);
+}
+
+test "alpha equivalence ignores param names" {
+    const body_hash: ContentHash = [_]u8{0xBB} ** 32;
+
+    const a = FunctionAst{
+        .name = "add",
+        .params = &.{
+            .{ .name = "x", .type_expr = "i32" },
+            .{ .name = "y", .type_expr = "i32" },
+        },
+        .return_type = "i32",
+        .body_hash = body_hash,
+    };
+
+    const b = FunctionAst{
+        .name = "add",
+        .params = &.{
+            .{ .name = "a", .type_expr = "i32" },
+            .{ .name = "b", .type_expr = "i32" },
+        },
+        .return_type = "i32",
+        .body_hash = body_hash,
+    };
+
+    try std.testing.expect(alphaEquivalent(a, b));
+}
+
+test "different types are not alpha equivalent" {
+    const body_hash: ContentHash = [_]u8{0xCC} ** 32;
+
+    const a = FunctionAst{
+        .name = "f",
+        .params = &.{.{ .name = "x", .type_expr = "i32" }},
+        .return_type = "i32",
+        .body_hash = body_hash,
+    };
+
+    const b = FunctionAst{
+        .name = "f",
+        .params = &.{.{ .name = "x", .type_expr = "f64" }},
+        .return_type = "i32",
+        .body_hash = body_hash,
+    };
+
+    try std.testing.expect(!alphaEquivalent(a, b));
+}
+
+test "different param count not alpha equivalent" {
+    const body_hash: ContentHash = [_]u8{0xDD} ** 32;
+
+    const a = FunctionAst{
+        .name = "f",
+        .params = &.{.{ .name = "x", .type_expr = "i32" }},
+        .return_type = "i32",
+        .body_hash = body_hash,
+    };
+
+    const b = FunctionAst{
+        .name = "f",
+        .params = &.{
+            .{ .name = "x", .type_expr = "i32" },
+            .{ .name = "y", .type_expr = "i32" },
+        },
+        .return_type = "i32",
+        .body_hash = body_hash,
+    };
+
+    try std.testing.expect(!alphaEquivalent(a, b));
+}
+
+test "hash to string produces 64 hex chars" {
+    const hash: ContentHash = [_]u8{0} ** 32;
+    const s = hashToString(hash);
+    try std.testing.expectEqual(@as(usize, 64), s.len);
+}
+
+test "normalize params canonicalizes names" {
+    const allocator = std.testing.allocator;
+    const params = [_]Param{
+        .{ .name = "foo", .type_expr = "i32" },
+        .{ .name = "bar", .type_expr = "f64" },
+    };
+    const normalized = try normalizeParams(&params, allocator);
+    defer allocator.free(normalized);
+
+    try std.testing.expectEqualStrings("_p0", normalized[0].canonical_name);
+    try std.testing.expectEqualStrings("_p1", normalized[1].canonical_name);
+    try std.testing.expectEqualStrings("i32", normalized[0].type_expr);
+    try std.testing.expectEqualStrings("f64", normalized[1].type_expr);
+}

--- a/src/tri_lang/content_registry.zig
+++ b/src/tri_lang/content_registry.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const ContentHash = @import("content_hash.zig").ContentHash;
+
+pub const FunctionLocation = struct {
+    file_path: []const u8,
+    line: u32,
+    hash: ContentHash,
+};
+
+pub const Registry = struct {
+    entries: std.StringHashMap(FunctionLocation),
+    allocator: std.mem.Allocator,
+
+    pub fn init(allocator: std.mem.Allocator) Registry {
+        return .{
+            .entries = std.StringHashMap(FunctionLocation).init(allocator),
+            .allocator = allocator,
+        };
+    }
+
+    pub fn deinit(self: *Registry) void {
+        var iter = self.entries.iterator();
+        while (iter.next()) |entry| {
+            self.allocator.free(entry.key_ptr.*);
+        }
+        self.entries.deinit();
+    }
+
+    pub fn register(self: *Registry, hash_hex: []const u8, location: FunctionLocation) !void {
+        const key = try self.allocator.dupe(u8, hash_hex);
+        const existing = self.entries.fetchPut(key, location) catch |err| {
+            self.allocator.free(key);
+            return err;
+        };
+        if (existing) |old| {
+            self.allocator.free(old.key);
+        }
+    }
+
+    pub fn lookup(self: *Registry, hash_hex: []const u8) ?FunctionLocation {
+        return self.entries.get(hash_hex);
+    }
+
+    pub fn hasHash(self: *Registry, hash_hex: []const u8) bool {
+        return self.entries.contains(hash_hex);
+    }
+
+    pub fn count(self: *Registry) usize {
+        return self.entries.count();
+    }
+
+    pub fn deduplicate(self: *Registry) usize {
+        var dedup = Registry.init(self.allocator);
+        defer dedup.deinit();
+
+        var iter = self.entries.iterator();
+        var removed: usize = 0;
+        while (iter.next()) |entry| {
+            if (dedup.hasHash(entry.key_ptr.*)) {
+                removed += 1;
+            } else {
+                dedup.register(entry.key_ptr.*, entry.value_ptr.*) catch {};
+            }
+        }
+        return removed;
+    }
+};
+
+test "register and lookup" {
+    const allocator = std.testing.allocator;
+    var reg = Registry.init(allocator);
+    defer reg.deinit();
+
+    const hash = "aa" ** 32;
+    const loc = FunctionLocation{
+        .file_path = "test.tri",
+        .line = 42,
+        .hash = [_]u8{0xAA} ** 32,
+    };
+
+    try reg.register(hash, loc);
+    try std.testing.expectEqual(@as(usize, 1), reg.count());
+
+    const found = reg.lookup(hash);
+    try std.testing.expect(found != null);
+    try std.testing.expectEqualStrings("test.tri", found.?.file_path);
+    try std.testing.expectEqual(@as(u32, 42), found.?.line);
+}
+
+test "duplicate registration updates" {
+    const allocator = std.testing.allocator;
+    var reg = Registry.init(allocator);
+    defer reg.deinit();
+
+    const hash = "bb" ** 32;
+    try reg.register(hash, .{ .file_path = "a.tri", .line = 1, .hash = [_]u8{0} ** 32 });
+    try reg.register(hash, .{ .file_path = "b.tri", .line = 2, .hash = [_]u8{0} ** 32 });
+
+    try std.testing.expectEqual(@as(usize, 1), reg.count());
+    try std.testing.expectEqualStrings("b.tri", reg.lookup(hash).?.file_path);
+}
+
+test "lookup missing returns null" {
+    const allocator = std.testing.allocator;
+    var reg = Registry.init(allocator);
+    defer reg.deinit();
+
+    try std.testing.expect(reg.lookup("nonexistent") == null);
+}


### PR DESCRIPTION
## Summary
Content-addressed function storage for TRI-LANG, inspired by Unison.

### Files
- `src/tri_lang/content_hash.zig` — SHA256 hashing of normalized ASTs, alpha-equivalence, param normalization
- `src/tri_lang/content_registry.zig` — Hash-to-location registry with register/lookup/dedup

### Features
- SHA256 of normalized function signature (return type + param types + body hash)
- Alpha-equivalence: `fn(x: i32)` == `fn(a: i32)` (param names don't affect hash)
- Param normalization to canonical `_p0, _p1, ...` form
- Registry with deduplication support

### Tests (8)
- Consistent hashing
- Alpha-equivalence (same types, different names)
- Non-equivalent types
- Different param count
- Hash to string
- Param normalization
- Registry register/lookup
- Duplicate registration updates

Closes #417