### PR TITLE
docs(clara): killweb dataset -> netalloc

### DIFF
--- a/docs/proposals/DARPA_CLARA_PROPOSAL.md
+++ b/docs/proposals/DARPA_CLARA_PROPOSAL.md
@@ -402,8 +402,8 @@ tri clara verify-complexity --expected O(n) --tolerance 1.2
 
 ```bash
 # Compare AR-assisted vs baseline training
-tri clara train --dataset killweb --mode baseline --epochs 100
-tri clara train --dataset killweb --mode ar-assisted --epochs 100
+tri clara train --dataset netalloc --mode baseline --epochs 100
+tri clara train --dataset netalloc --mode ar-assisted --epochs 100
 
 # Measure sample efficiency
 tri clara analyze --metric sample_complexity --baseline results/baseline.json \


### PR DESCRIPTION
§4.2 trained on `--dataset killweb` (2x) while §5.1 is now the civilian 'Resilient Network Resource Allocation'. Rename dataset to `netalloc` for consistency (TRI-NET / civilian).